### PR TITLE
fix: wrong gdc on 3 authproxy endpoints + refresh() status blind spot causing endless reauth loop for combustion vehicles

### DIFF
--- a/custom_components/volkswagen_connect/coordinator.py
+++ b/custom_components/volkswagen_connect/coordinator.py
@@ -270,8 +270,16 @@ class VolkswagenConnectCoordinator(DataUpdateCoordinator[dict[str, VehicleData]]
                 for raw, clean in _MAINTENANCE_MAP.items():
                     if maint.get(raw) is not None:
                         data.values[clean] = maint[raw]
-                # Live battery/charging telemetry (already clean keys).
-                data.values.update(await self.portal.get_charging(vin))
+                # Live battery/charging telemetry (already clean keys). Not every
+                # vehicle has a battery - a combustion car 412s here even with a
+                # perfectly valid session, so treat that as "no charging data"
+                # instead of tearing down the whole update as an auth failure.
+                try:
+                    data.values.update(await self.portal.get_charging(vin))
+                except WebsitePortalAuthError as err:
+                    _LOGGER.debug(
+                        "No charging data for %s (likely not an EV): %s", vin, err
+                    )
                 # Vehicle-health warning lights + last lock/unlock command.
                 data.values.update(await self.portal.get_warning_lights(vin))
                 data.values.update(await self.portal.get_lock_history(vin))

--- a/custom_components/volkswagen_connect/website_portal.py
+++ b/custom_components/volkswagen_connect/website_portal.py
@@ -277,6 +277,8 @@ class WebsitePortalClient:
                 max_redirects=MAX_REDIRECTS,
             ) as r:
                 url = str(r.url)
+                status = r.status
+                body = await r.text()
         except aiohttp.TooManyRedirects as err:
             # A genuine loop (not just a long chain). A consent hop in the
             # history means the consent wall is bouncing us — tell the user.
@@ -306,6 +308,15 @@ class WebsitePortalClient:
             )
         if not (urlparse(url).hostname or "").endswith("volkswagen.de"):
             raise WebsitePortalAuthError(f"refresh did not land on portal: {url}")
+        # Landing on a volkswagen.de URL is necessary but not sufficient: the
+        # chain can also terminate on a non-2xx error response (e.g. 412) that
+        # still resolves to a volkswagen.de host, which every check above would
+        # wave through as "ok" while the session is actually still dead.
+        if status != 200:
+            _LOGGER.debug("Portal refresh landed with HTTP %d: %s", status, body[:300])
+            raise WebsitePortalAuthError(
+                f"refresh landed on portal but HTTP {status}; re-auth required"
+            )
 
     # -- data ---------------------------------------------------------------
 
@@ -369,7 +380,7 @@ class WebsitePortalClient:
         """Returns mileage_km, inspectionDue_days/km, oilServiceDue_*, carCapturedTimestamp."""
         status, body = await self._get(
             f"/app/authproxy/vw-de/proxy/vehicles/{vin}/maintenance/status"
-            "?gdc=myvw-wcar-prod&resourceHost=myvw-vcf-prod",
+            "?gdc=myvw-mbb-prod&resourceHost=myvw-vcf-prod",
             accept="*/*",
         )
         if status != 200:
@@ -432,7 +443,7 @@ class WebsitePortalClient:
         """
         status, body = await self._get(
             f"/app/authproxy/vwag-weconnect/proxy/vehicles/{vin}/warninglights/last"
-            "?gdc=myvw-wcar-prod&resourceHost=myvw-vcf-prod",
+            "?gdc=myvw-mbb-prod&resourceHost=myvw-vcf-prod",
             accept="*/*",
         )
         if status != 200:
@@ -458,7 +469,7 @@ class WebsitePortalClient:
         """
         status, body = await self._get(
             f"/app/authproxy/vw-de/proxy/vehicles/{vin}/transactionhistory"
-            "?gdc=myvw-wcar-prod&resourceHost=myvw-vcf-prod",
+            "?gdc=myvw-mbb-prod&resourceHost=myvw-vcf-prod",
             accept="*/*",
         )
         if status != 200:

--- a/custom_components/volkswagen_connect/website_portal.py
+++ b/custom_components/volkswagen_connect/website_portal.py
@@ -122,6 +122,7 @@ class WebsitePortalClient:
         self._email = email
         self._password = password
         self._mfa: dict[str, Any] | None = None
+        self._gdc_cache: dict[str, str] = {}
 
     # -- cookie persistence -------------------------------------------------
 
@@ -376,11 +377,46 @@ class WebsitePortalClient:
         m = re.findall(r'"vin"\s*:\s*"([A-Z0-9]{17})"', body)
         return m[0] if m else None
 
+    async def _gdc_for(self, vin: str) -> str:
+        """Resolve the authproxy backend cluster ('gdc') this vehicle is routed to.
+
+        VW's own frontend picks this per vehicle rather than using one fixed
+        value - a hardcoded "myvw-wcar-prod" 412s (Precondition Failed) for
+        vehicles routed elsewhere, regardless of session validity. The
+        relation record names the real backend directly as
+        relation.vehicle.modBackend (e.g. "MBB_ODP" for a combustion Tiguan);
+        take the prefix before the underscore, lowercased, as the gdc value.
+        Cached per VIN - this doesn't change for the life of a session. Falls
+        back to "mbb" (the more common ICE backend) if the field is missing
+        or the shape changes, rather than blocking every data call.
+        """
+        if vin in self._gdc_cache:
+            return self._gdc_cache[vin]
+        gdc = "mbb"
+        try:
+            status, body = await self._get(
+                f"/app/authproxy/vw-de/proxy/v2/users/me/relations/{vin}"
+                "?resourceHost=myvw-vum-prod"
+            )
+            if status == 200:
+                mod_backend = (
+                    json.loads(body).get("relation", {}).get("vehicle", {}).get("modBackend")
+                    or ""
+                )
+                prefix = mod_backend.split("_", 1)[0]
+                if prefix:
+                    gdc = prefix.lower()
+        except (ValueError, WebsitePortalAuthError) as err:
+            _LOGGER.debug("Could not resolve gdc for %s, defaulting to %r: %s", vin, gdc, err)
+        self._gdc_cache[vin] = gdc
+        return gdc
+
     async def get_maintenance(self, vin: str) -> dict[str, Any]:
         """Returns mileage_km, inspectionDue_days/km, oilServiceDue_*, carCapturedTimestamp."""
+        gdc = await self._gdc_for(vin)
         status, body = await self._get(
             f"/app/authproxy/vw-de/proxy/vehicles/{vin}/maintenance/status"
-            "?gdc=myvw-mbb-prod&resourceHost=myvw-vcf-prod",
+            f"?gdc=myvw-{gdc}-prod&resourceHost=myvw-vcf-prod",
             accept="*/*",
         )
         if status != 200:
@@ -398,9 +434,10 @@ class WebsitePortalClient:
         charge_power, charge_rate, charge_time_remaining, charge_mode,
         plug_connection, plug_lock, external_power.
         """
+        gdc = await self._gdc_for(vin)
         status, body = await self._get(
             f"/app/authproxy/vwag-weconnect/proxy/vehicles/{vin}/charging/status"
-            "?gdc=myvw-wcar-prod&resourceHost=myvw-vcf-prod",
+            f"?gdc=myvw-{gdc}-prod&resourceHost=myvw-vcf-prod",
             accept="*/*",
         )
         if status != 200:
@@ -441,9 +478,10 @@ class WebsitePortalClient:
         warninglights/last returns the currently-active dashboard warning lights;
         an empty list means everything is OK (count 0).
         """
+        gdc = await self._gdc_for(vin)
         status, body = await self._get(
             f"/app/authproxy/vwag-weconnect/proxy/vehicles/{vin}/warninglights/last"
-            "?gdc=myvw-mbb-prod&resourceHost=myvw-vcf-prod",
+            f"?gdc=myvw-{gdc}-prod&resourceHost=myvw-vcf-prod",
             accept="*/*",
         )
         if status != 200:
@@ -467,9 +505,10 @@ class WebsitePortalClient:
         available signal. Keys: last_lock_action ("lock"/"unlock"),
         last_lock_action_time (ISO timestamp).
         """
+        gdc = await self._gdc_for(vin)
         status, body = await self._get(
             f"/app/authproxy/vw-de/proxy/vehicles/{vin}/transactionhistory"
-            "?gdc=myvw-mbb-prod&resourceHost=myvw-vcf-prod",
+            f"?gdc=myvw-{gdc}-prod&resourceHost=myvw-vcf-prod",
             accept="*/*",
         )
         if status != 200:


### PR DESCRIPTION
## Summary

Combustion-engine vehicles (no EV battery) got stuck in an endless "Volkswagen session expired; please log in again" loop: every reauth reported success, but the very next poll failed the exact same way. Root cause turned out to be unrelated to authentication.

- `get_maintenance()`, `get_charging()`, `get_warning_lights()`, `get_lock_history()` all hardcoded `gdc=myvw-wcar-prod`. Turns out VW doesn't use one fixed backend cluster for these calls — it's per-vehicle. The relation record names it directly: `GET .../v2/users/me/relations/{vin}?resourceHost=myvw-vum-prod` returns `relation.vehicle.modBackend` (e.g. `"MBB_ODP"` for a combustion Tiguan, confirmed via a captured browser request). That backend rejects requests routed to the wrong cluster with `412 Precondition Failed`, regardless of session validity. `_gdc_for()` now resolves and caches the correct value per VIN from that field instead of guessing.
- `refresh()` only checked that the final redirect landed on a `volkswagen.de` host, never its HTTP status. A redirect chain can terminate on a non-2xx response that still resolves to that host — silently treated as a successful refresh, masking a dead session as "ok". Combined with the gdc issue, every reauth attempt looked successful right up until the next real data call failed for an unrelated reason. `refresh()` now also requires `status == 200`.
- Even with the right backend, `get_charging()` can legitimately fail for a non-EV vehicle (no battery, no charging data — on this account it now correctly surfaces `403 "missing user consent"` rather than a misleading generic 412). Previously this aborted the whole coordinator update as an auth failure; now it's caught and logged as "no charging data for this vehicle", and the rest of the update (odometer, maintenance, warning lights, images, etc.) still goes through.

Debugged and verified live against a real account/vehicle (VW Tiguan Allspace, diesel) via `logger: custom_components.volkswagen_connect: debug`, HA restart/reauth cycles, and comparing response bodies against captured working browser requests for the same endpoints.

## Test plan

- [x] Deployed to a live HA instance, `ha core check` clean, restarted
- [x] Full reauth cycle completes without looping back into `ConfigEntryAuthFailed`
- [x] Full update cycle logs `success: True`
- [x] All expected entities populate: odometer, inspection/oil-service due, tyre pressure, doors/locks, warning lights, vehicle images
- [x] Non-EV vehicle no longer aborts the update on the charging-endpoint failure; other data still refreshes, and the logged reason is now accurate (403 consent, not a generic 412)