### PR TITLE
Curate door/window/lock state sensors + fix mileage sentinel and temperature scale

### DIFF
--- a/custom_components/volkswagen_connect/binary_sensor.py
+++ b/custom_components/volkswagen_connect/binary_sensor.py
@@ -7,6 +7,7 @@ true/false text. These keys are handled here and skipped by the sensor platform.
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from homeassistant.components.binary_sensor import (
@@ -23,19 +24,79 @@ from .coordinator import VolkswagenConnectConfigEntry, VolkswagenConnectCoordina
 
 # Boolean keys exposed as binary sensors with a device class. ``invert`` maps our
 # value to HA's on/off convention (the lock device class reads on = unlocked).
+# ``encoding`` selects how the raw value is decoded (see _DECODERS below);
+# defaults to "bool" (VW's plain true/false fields).
 BINARY_KEYS: dict[str, dict[str, Any]] = {
     "locked": {"name": "Lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True},
     "open": {"name": "Open", "device_class": BinarySensorDeviceClass.OPENING},
     "trunk.locked": {"name": "Trunk lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True},
     "trunk.open": {"name": "Trunk", "device_class": BinarySensorDeviceClass.OPENING},
+    "parking_brake": {"name": "Parking brake", "encoding": "onoff"},
+    "parking_lights": {"name": "Parking lights", "device_class": BinarySensorDeviceClass.LIGHT, "encoding": "lights"},
+    # Per-door/component state fields from the EU Data Act "access" cluster.
+    # VW encodes these as 0=unsupported, 1=invalid, 2/3=the two real states
+    # (which one is "2" depends on the field - see each comment below). This
+    # mapping isn't officially documented by VW; it's cross-checked against
+    # the equivalent decoding in the sibling TommiG1/HA_VAG-EU-Data-Act
+    # project (same EU Data Act backend, used by Audi/Skoda/Cupra/Seat too).
+    # The raw code is still exposed as the `raw_value` attribute so you can
+    # verify it yourself (open a door, watch it flip between 2 and 3).
+    #
+    # Lock states: 2 = locked, 3 = unlocked.
+    "locked_state_front_left_door": {"name": "Front left door lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state"},
+    "locked_state_front_right_door": {"name": "Front right door lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state"},
+    # VW's own dataFieldName has a double underscore here (confirmed against
+    # the actual delivered payload) - every other door uses a single one.
+    "locked_state__rear_left_door": {"name": "Rear left door lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state"},
+    "locked_state_rear_right_door": {"name": "Rear right door lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state"},
+    "locked_state_tailgate": {"name": "Tailgate lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state"},
+    "locked_state_front_engine_bonnet": {"name": "Bonnet lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state"},
+    # Open states: 2 = open, 3 = closed.
+    "open_state_front_left_door": {"name": "Front left door", "device_class": BinarySensorDeviceClass.DOOR, "encoding": "state"},
+    "open_state_front_right_door": {"name": "Front right door", "device_class": BinarySensorDeviceClass.DOOR, "encoding": "state"},
+    "open_state_rear_left_door": {"name": "Rear left door", "device_class": BinarySensorDeviceClass.DOOR, "encoding": "state"},
+    "open_state_rear_right_door": {"name": "Rear right door", "device_class": BinarySensorDeviceClass.DOOR, "encoding": "state"},
+    "open_state_tailgate": {"name": "Tailgate", "device_class": BinarySensorDeviceClass.DOOR, "encoding": "state"},
+    "open_state_front_engine_bonnet": {"name": "Bonnet", "device_class": BinarySensorDeviceClass.DOOR, "encoding": "state"},
+    # Safe/latched states. The sibling project's comment claims 2=safe/3=unsafe
+    # (matching the other "state" fields' 2/3 order), but on this Tiguan that
+    # produced "Dangereux" on every door/hood/tailgate while fully closed and
+    # locked — so this field is inverted relative to the others: observed
+    # behaviour is 2 = unsafe, 3 = safe (properly latched).
+    "safe_state_front_left_door": {"name": "Front left door latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state"},
+    "safe_state_front_right_door": {"name": "Front right door latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state"},
+    "safe_state_rear_left_door": {"name": "Rear left door latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state"},
+    "safe_state_rear_right_door": {"name": "Rear right door latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state"},
+    "safe_state_tailgate": {"name": "Tailgate latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state"},
+    "safe_state_front_engine_bonnet": {"name": "Bonnet latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state"},
+    # Window lifter / sunroof states: 2 = open, 3 = closed.
+    "state_front_left_door_window_lifter": {"name": "Front left window", "device_class": BinarySensorDeviceClass.WINDOW, "encoding": "state"},
+    "state_front_right_door_window_lifter": {"name": "Front right window", "device_class": BinarySensorDeviceClass.WINDOW, "encoding": "state"},
+    "state_rear_left_door_window_lifter": {"name": "Rear left window", "device_class": BinarySensorDeviceClass.WINDOW, "encoding": "state"},
+    "state_rear_right_door_window_lifter": {"name": "Rear right window", "device_class": BinarySensorDeviceClass.WINDOW, "encoding": "state"},
+    "state_sunroof_motor_hood_1": {"name": "Sunroof", "device_class": BinarySensorDeviceClass.WINDOW, "encoding": "state"},
+    "state_sunroof_motor_hood_3": {"name": "Sunroof motor 3", "encoding": "state"},
+    "state_of_hood": {"name": "Hood", "device_class": BinarySensorDeviceClass.OPENING, "encoding": "state"},
+    "state_service_hatch": {"name": "Service hatch (fuel/charge flap)", "device_class": BinarySensorDeviceClass.OPENING, "encoding": "state"},
+    "state_spoiler": {"name": "Spoiler", "device_class": BinarySensorDeviceClass.OPENING, "encoding": "state"},
 }
 
 _TRUE = {"true", "1", "on", "yes"}
 _FALSE = {"false", "0", "off", "no"}
 
 
+def _as_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and re.fullmatch(r"-?\d+", value.strip()):
+        return int(value.strip())
+    return None
+
+
 def _as_bool(value: Any) -> bool | None:
-    """Coerce VW's true/false (string or bool) to a real bool, else None."""
+    """Coerce VW's plain true/false (string or bool) to a real bool, else None."""
     if isinstance(value, bool):
         return value
     if isinstance(value, str):
@@ -45,6 +106,37 @@ def _as_bool(value: Any) -> bool | None:
         if s in _FALSE:
             return False
     return None
+
+
+def _decode_state_code(value: Any) -> bool | None:
+    """Decode VW's 4-value door/lock/window/safety code: 0/1 = unsupported /
+    invalid (-> unknown), 2 = the field's "active" state, 3 = its opposite."""
+    iv = _as_int(value)
+    if iv is None or iv in (0, 1):
+        return None
+    return iv == 2
+
+
+def _decode_onoff(value: Any) -> bool | None:
+    """0/1 int -> off/on (e.g. parking_brake)."""
+    iv = _as_int(value)
+    return None if iv is None else bool(iv)
+
+
+def _decode_lights(value: Any) -> bool | None:
+    """0/1 = unsupported/invalid (-> unknown); 2 = off; 3/4/5 = on."""
+    iv = _as_int(value)
+    if iv is None or iv in (0, 1):
+        return None
+    return iv in (3, 4, 5)
+
+
+_DECODERS = {
+    "bool": _as_bool,
+    "state": _decode_state_code,
+    "onoff": _decode_onoff,
+    "lights": _decode_lights,
+}
 
 
 async def async_setup_entry(
@@ -96,9 +188,11 @@ class VolkswagenConnectBinarySensor(
         self._key = key
         meta = BINARY_KEYS[key]
         self._invert = meta.get("invert", False)
+        self._decode = _DECODERS[meta.get("encoding", "bool")]
         self._attr_unique_id = f"{vin}_{key}"
         self._attr_name = meta["name"]
-        self._attr_device_class = meta["device_class"]
+        if "device_class" in meta:
+            self._attr_device_class = meta["device_class"]
 
     @property
     def _vehicle(self) -> VehicleData | None:
@@ -112,7 +206,7 @@ class VolkswagenConnectBinarySensor(
     @property
     def is_on(self) -> bool | None:
         v = self._vehicle
-        b = _as_bool(v.values.get(self._key)) if v else None
+        b = self._decode(v.values.get(self._key)) if v else None
         if b is None:
             return None
         return (not b) if self._invert else b
@@ -126,4 +220,4 @@ class VolkswagenConnectBinarySensor(
     @property
     def available(self) -> bool:
         v = self._vehicle
-        return super().available and v is not None and _as_bool(v.values.get(self._key)) is not None
+        return super().available and v is not None and self._decode(v.values.get(self._key)) is not None

--- a/custom_components/volkswagen_connect/coordinator.py
+++ b/custom_components/volkswagen_connect/coordinator.py
@@ -193,7 +193,11 @@ class VolkswagenConnectCoordinator(DataUpdateCoordinator[dict[str, VehicleData]]
                     data.dataset = latest["dataset"]
                     data.created_on = latest["created_on"]
                     data.values = dict(latest["values"])
-                    data.captured_at = _best_captured_at(data.values)
+                    # Flat (pre-ID.x) payloads carry no dedicated capture-time
+                    # field; latest["captured_at"] (the per-record timestampUtc)
+                    # covers those. Dotted payloads without it fall back to
+                    # searching the extracted values for a named field.
+                    data.captured_at = latest.get("captured_at") or _best_captured_at(data.values)
             except EuDataActNotConfigured:
                 data.status = STATUS_NOT_CONFIGURED
             except EuDataActAuthError as err:

--- a/custom_components/volkswagen_connect/eu_data_act.py
+++ b/custom_components/volkswagen_connect/eu_data_act.py
@@ -185,6 +185,9 @@ _SKIP_FIELDS = {
     "state",
     "value",
     "timestamp",
+    # API health-check artifact (observed value is the literal string "echo"),
+    # not vehicle telemetry.
+    "echo",
 }
 
 # Some documented signals ship with the generic placeholder dataFieldName
@@ -198,19 +201,28 @@ _KNOWN_DATA_KEYS = {
 }
 
 
+# 32-bit "unset" sentinel VW sends for a field it has no real reading for
+# (e.g. mileage on a car that hasn't reported it yet). Not a real distance -
+# dropping it to None avoids showing a nonsense multi-billion-km odometer.
+_UINT32_SENTINEL = 2**32 - 1
+
+
 def _coerce(value: Any) -> Any:
     """Turn obviously-numeric string values into int/float so they can graph.
 
-    Also unwraps the ``<n>s`` second-duration form VW uses (e.g. ``6900s``).
+    Also unwraps the ``<n>s`` second-duration form VW uses (e.g. ``6900s``)
+    and drops the 32-bit "unset" sentinel value (see ``_UINT32_SENTINEL``).
     """
     if isinstance(value, str):
         v = value.strip()
         if re.fullmatch(r"-?\d+", v):
-            return int(v)
-        if re.fullmatch(r"-?\d*\.\d+", v):
-            return float(v)
-        if re.fullmatch(r"\d+s", v):  # "6900s" -> 6900 (seconds)
-            return int(v[:-1])
+            value = int(v)
+        elif re.fullmatch(r"-?\d*\.\d+", v):
+            value = float(v)
+        elif re.fullmatch(r"\d+s", v):  # "6900s" -> 6900 (seconds)
+            value = int(v[:-1])
+    if isinstance(value, int) and not isinstance(value, bool) and value == _UINT32_SENTINEL:
+        return None
     return value
 
 

--- a/custom_components/volkswagen_connect/eu_data_act.py
+++ b/custom_components/volkswagen_connect/eu_data_act.py
@@ -226,23 +226,34 @@ def _coerce(value: Any) -> Any:
     return value
 
 
-def _extract_values(raw: dict[str, Any]) -> dict[str, Any]:
-    """Turn an EU Data Act dataset into ``{dataFieldName: latest value}``.
+def _extract_values(raw: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
+    """Turn an EU Data Act dataset into ``{dataFieldName: latest value}``, plus
+    the newest ``timestampUtc`` seen across all records.
 
-    The payload's ``Data`` array is a flat list of ``{key, dataFieldName, value}``
-    records — typically several timestamped samples of the same field. We key by
-    ``dataFieldName`` (which is stable across the 15-min deliveries) and keep the
-    last value seen, so each signal maps to exactly one sensor that tracks its
-    most recent reading. Inner docs that don't use this shape fall back to a
-    generic flatten.
+    The payload's ``Data`` array is a flat list of ``{key, dataFieldName, value,
+    timestampUtc}`` records — typically several timestamped samples of the same
+    field. We key by ``dataFieldName`` (which is stable across the 15-min
+    deliveries) and keep the last value seen, so each signal maps to exactly
+    one sensor that tracks its most recent reading. Inner docs that don't use
+    this shape fall back to a generic flatten (no per-record timestamp then).
+
+    ``timestampUtc`` is the moment the car reported that record - on flat
+    (pre-ID.x) payloads it's the only capture-time signal available (there is
+    no dedicated ``car_captured_time`` field), and every record in a delivery
+    carries the same value, so the max across the batch is that delivery's
+    capture time.
     """
     out: dict[str, Any] = {}
+    latest_ts: str | None = None
     for doc in raw.values():
         records = (doc.get("Data") or doc.get("data")) if isinstance(doc, dict) else None
         if isinstance(records, list):
             for r in records:
                 if not isinstance(r, dict):
                     continue
+                ts = r.get("timestampUtc")
+                if isinstance(ts, str) and (latest_ts is None or ts > latest_ts):
+                    latest_ts = ts
                 name = r.get("dataFieldName") or r.get("datafieldname")
                 # Recover a documented signal whose placeholder name would
                 # otherwise be skipped, by resolving its stable key UUID.
@@ -257,7 +268,7 @@ def _extract_values(raw: dict[str, Any]) -> dict[str, Any]:
                 out[name] = _coerce(r.get("value"))
         elif isinstance(doc, (dict, list)):
             out.update(flatten(doc))
-    return out
+    return out, latest_ts
 
 
 class EuDataActClient:
@@ -449,8 +460,11 @@ class EuDataActClient:
     async def get_latest(self, vin: str, identifier: str | None = None) -> dict | None:
         """Convenience: newest content dataset for a VIN, parsed + flattened.
 
-        Returns {identifier, dataset, created_on, raw, values} or None when no
-        content has been delivered yet (e.g. car idle / request just activated).
+        Returns {identifier, dataset, created_on, raw, values, captured_at} or
+        None when no content has been delivered yet (e.g. car idle / request
+        just activated). ``captured_at`` is the newest per-record
+        ``timestampUtc`` in the dataset (see _extract_values) - None if the
+        payload didn't carry one.
         """
         if identifier is None:
             identifier = (await self.get_metadata(vin)).get("Identifier")
@@ -462,12 +476,14 @@ class EuDataActClient:
             return None
         newest = max(content, key=lambda d: str(d.get("createdOn") or d.get("name")))
         raw = await self.download_dataset(vin, identifier, newest["name"])
+        values, captured_at = _extract_values(raw)
         return {
             "identifier": identifier,
             "dataset": newest["name"],
             "created_on": newest.get("createdOn"),
             "raw": raw,
-            "values": _extract_values(raw),
+            "values": values,
+            "captured_at": captured_at,
         }
 
 

--- a/custom_components/volkswagen_connect/sensor.py
+++ b/custom_components/volkswagen_connect/sensor.py
@@ -82,6 +82,11 @@ KNOWN_KEYS: dict[str, dict[str, Any]] = {
     "cruising_range_secondary_engine": {"name": "Range (secondary)", "device_class": SensorDeviceClass.DISTANCE, "unit": UnitOfLength.KILOMETERS, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:ev-station"},
     "fuel_level_current_level": {"name": "Fuel level", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:gas-station"},
     "fuel_level__accuracy": {"name": "Fuel level accuracy", "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:gauge", "category": EntityCategory.DIAGNOSTIC},
+    # oil_level_total_max (a 0-1 scale reference, not a liter capacity - the
+    # sibling vw_eu_data_act project labels it "L" but that doesn't match a
+    # real engine's oil capacity) is left uncurated; this is the meaningful
+    # percentage gauge.
+    "oil_level_actual_level": {"name": "Oil level", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:oil-level"},
     "cng_gas_level": {"name": "CNG gas level", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:gas-cylinder"},
     "position_front_left_door_window_lifter": {"name": "Front left window position", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:window-open-variant", "category": EntityCategory.DIAGNOSTIC},
     "position_front_right_door_window_lifter": {"name": "Front right window position", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:window-open-variant", "category": EntityCategory.DIAGNOSTIC},

--- a/custom_components/volkswagen_connect/sensor.py
+++ b/custom_components/volkswagen_connect/sensor.py
@@ -29,6 +29,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -51,6 +52,18 @@ MAX_VALUE_SENSORS_PER_VEHICLE = 100
 # every 15 min, so 30 min = the car hasn't reported in two cycles.
 STALE_AFTER_MINUTES = 30
 
+def _decikelvin_to_celsius(value: Any) -> Any:
+    """Convert VW's deci-Kelvin encoding (e.g. 2991 -> 25.9 °C) to Celsius.
+
+    Confirmed against the equivalent transform in the sibling vw_eu_data_act
+    integration (also installed on this system, pulling the same EU Data Act
+    feed): outside_temperature is reported in tenths of a Kelvin.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return value
+    return round(value / 10 - 273.15, 1)
+
+
 # Friendly metadata for known (authproxy-derived) keys. Unknown keys still get
 # a generic sensor.
 KNOWN_KEYS: dict[str, dict[str, Any]] = {
@@ -61,6 +74,20 @@ KNOWN_KEYS: dict[str, dict[str, Any]] = {
         "state_class": SensorStateClass.TOTAL_INCREASING,
         "icon": "mdi:counter",
     },
+    # Flat (pre-ID.x) mileage/range fields - this Tiguan reports these instead
+    # of the dotted "mileage.value"/"primary_range" equivalents above.
+    "mileage": {"name": "Mileage", "device_class": SensorDeviceClass.DISTANCE, "unit": UnitOfLength.KILOMETERS, "state_class": SensorStateClass.TOTAL_INCREASING, "icon": "mdi:counter"},
+    "cruising_range_combined": {"name": "Range (combined)", "device_class": SensorDeviceClass.DISTANCE, "unit": UnitOfLength.KILOMETERS, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:map-marker-distance"},
+    "cruising_range_primary_engine": {"name": "Range (primary)", "device_class": SensorDeviceClass.DISTANCE, "unit": UnitOfLength.KILOMETERS, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:gas-station"},
+    "cruising_range_secondary_engine": {"name": "Range (secondary)", "device_class": SensorDeviceClass.DISTANCE, "unit": UnitOfLength.KILOMETERS, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:ev-station"},
+    "fuel_level_current_level": {"name": "Fuel level", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:gas-station"},
+    "fuel_level__accuracy": {"name": "Fuel level accuracy", "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:gauge", "category": EntityCategory.DIAGNOSTIC},
+    "cng_gas_level": {"name": "CNG gas level", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:gas-cylinder"},
+    "position_front_left_door_window_lifter": {"name": "Front left window position", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:window-open-variant", "category": EntityCategory.DIAGNOSTIC},
+    "position_front_right_door_window_lifter": {"name": "Front right window position", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:window-open-variant", "category": EntityCategory.DIAGNOSTIC},
+    "position_rear_left_door_window_lifter": {"name": "Rear left window position", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:window-open-variant", "category": EntityCategory.DIAGNOSTIC},
+    "position_rear_right_door_window_lifter": {"name": "Rear right window position", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:window-open-variant", "category": EntityCategory.DIAGNOSTIC},
+    "position_sunroof_motor_hood_1": {"name": "Sunroof position", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:car-convertible", "category": EntityCategory.DIAGNOSTIC},
     "inspection_due_days": {"name": "Inspection due", "unit": UnitOfTime.DAYS, "icon": "mdi:wrench-clock"},
     "inspection_due_km": {"name": "Inspection due", "device_class": SensorDeviceClass.DISTANCE, "unit": UnitOfLength.KILOMETERS},
     "oil_service_due_days": {"name": "Oil service due", "unit": UnitOfTime.DAYS, "icon": "mdi:oil"},
@@ -68,20 +95,20 @@ KNOWN_KEYS: dict[str, dict[str, Any]] = {
     "last_report": {"name": "Last vehicle report", "device_class": SensorDeviceClass.TIMESTAMP, "icon": "mdi:clock-check"},
     # Vehicle health + lock history (from the authproxy)
     "warning_lights": {"name": "Warning lights", "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:car-light-alert"},
-    "last_lock_action": {"name": "Last lock command", "icon": "mdi:car-key"},
-    "last_lock_action_time": {"name": "Last lock command time", "device_class": SensorDeviceClass.TIMESTAMP, "icon": "mdi:clock-outline"},
+    "last_lock_action": {"name": "Last lock command", "icon": "mdi:car-key", "category": EntityCategory.DIAGNOSTIC},
+    "last_lock_action_time": {"name": "Last lock command time", "device_class": SensorDeviceClass.TIMESTAMP, "icon": "mdi:clock-outline", "category": EntityCategory.DIAGNOSTIC},
     # Live battery / charging (from charging/status)
     "soc": {"name": "Battery", "device_class": SensorDeviceClass.BATTERY, "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT},
     "electric_range": {"name": "Electric range", "device_class": SensorDeviceClass.DISTANCE, "unit": UnitOfLength.KILOMETERS, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:map-marker-distance"},
     "target_soc": {"name": "Target battery", "unit": PERCENTAGE, "icon": "mdi:battery-charging-high"},
-    "battery_temp": {"name": "Battery temperature", "device_class": SensorDeviceClass.TEMPERATURE, "unit": UnitOfTemperature.CELSIUS, "state_class": SensorStateClass.MEASUREMENT},
+    "battery_temp": {"name": "Battery temperature", "device_class": SensorDeviceClass.TEMPERATURE, "unit": UnitOfTemperature.CELSIUS, "state_class": SensorStateClass.MEASUREMENT, "category": EntityCategory.DIAGNOSTIC},
     "charging_state": {"name": "Charging state", "icon": "mdi:ev-station"},
     "charge_power": {"name": "Charge power", "device_class": SensorDeviceClass.POWER, "unit": UnitOfPower.KILO_WATT, "state_class": SensorStateClass.MEASUREMENT},
     "charge_rate": {"name": "Charge rate", "unit": UnitOfSpeed.KILOMETERS_PER_HOUR, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:speedometer"},
     "charge_time_remaining": {"name": "Charge time remaining", "device_class": SensorDeviceClass.DURATION, "unit": UnitOfTime.MINUTES, "icon": "mdi:timer-sand"},
     "charge_mode": {"name": "Charge mode", "icon": "mdi:cog"},
     "plug_connection": {"name": "Plug", "icon": "mdi:power-plug"},
-    "plug_lock": {"name": "Plug lock", "icon": "mdi:lock"},
+    "plug_lock": {"name": "Plug lock", "icon": "mdi:lock", "category": EntityCategory.DIAGNOSTIC},
     "external_power": {"name": "External power", "icon": "mdi:transmission-tower"},
     # --- EU Data Act fields (dataFieldName keys) --------------------------------
     # Friendly labels + units for the meaningful "continuous data" signals. The
@@ -92,39 +119,40 @@ KNOWN_KEYS: dict[str, dict[str, Any]] = {
     "battery_state_report.soc": {"name": "Battery state of charge", "device_class": SensorDeviceClass.BATTERY, "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT},
     "battery_state_report.charge_power": {"name": "Charge power (report)", "device_class": SensorDeviceClass.POWER, "unit": UnitOfPower.KILO_WATT, "state_class": SensorStateClass.MEASUREMENT},
     "battery_state_report.charge_rate": {"name": "Charge rate (report)", "unit": UnitOfSpeed.KILOMETERS_PER_HOUR, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:speedometer"},
-    "battery_state_report.charge_energy": {"name": "Charge energy", "device_class": SensorDeviceClass.ENERGY, "unit": UnitOfEnergy.KILO_WATT_HOUR, "icon": "mdi:lightning-bolt"},
-    "battery_care_mode.charge_bcam_threshold": {"name": "Battery care threshold", "unit": PERCENTAGE, "icon": "mdi:battery-heart-variant"},
-    "settings.target_soc": {"name": "Target SoC (setting)", "unit": PERCENTAGE, "icon": "mdi:battery-charging-high"},
+    "battery_state_report.charge_energy": {"name": "Charge energy", "device_class": SensorDeviceClass.ENERGY, "unit": UnitOfEnergy.KILO_WATT_HOUR, "icon": "mdi:lightning-bolt", "category": EntityCategory.DIAGNOSTIC},
+    "battery_care_mode.charge_bcam_threshold": {"name": "Battery care threshold", "unit": PERCENTAGE, "icon": "mdi:battery-heart-variant", "category": EntityCategory.DIAGNOSTIC},
+    "settings.target_soc": {"name": "Target SoC (setting)", "unit": PERCENTAGE, "icon": "mdi:battery-charging-high", "category": EntityCategory.DIAGNOSTIC},
     "outdoor_temperature": {"name": "Outdoor temperature", "device_class": SensorDeviceClass.TEMPERATURE, "unit": UnitOfTemperature.CELSIUS, "state_class": SensorStateClass.MEASUREMENT},
+    # Flat (pre-ID.x) equivalent of "outdoor_temperature", reported in deci-Kelvin.
+    "outside_temperature": {"name": "Outside temperature", "device_class": SensorDeviceClass.TEMPERATURE, "unit": UnitOfTemperature.CELSIUS, "state_class": SensorStateClass.MEASUREMENT, "transform": _decikelvin_to_celsius},
     # Per VW's Data Dictionary: coldest/warmest battery *module* temperature.
-    "min_temperature": {"name": "Battery module min temperature", "device_class": SensorDeviceClass.TEMPERATURE, "unit": UnitOfTemperature.CELSIUS, "state_class": SensorStateClass.MEASUREMENT},
-    "max_temperature": {"name": "Battery module max temperature", "device_class": SensorDeviceClass.TEMPERATURE, "unit": UnitOfTemperature.CELSIUS, "state_class": SensorStateClass.MEASUREMENT},
-    "car_captured_time": {"name": "Car captured time", "device_class": SensorDeviceClass.TIMESTAMP, "icon": "mdi:clock-check"},
-    "car_captured_utc_timestamp": {"name": "Car captured (UTC)", "device_class": SensorDeviceClass.TIMESTAMP, "icon": "mdi:clock-outline"},
-    "instrument_cluster_time": {"name": "Instrument cluster time", "device_class": SensorDeviceClass.TIMESTAMP, "icon": "mdi:clock-outline"},
-    "profile_state_report.car_captured_time": {"name": "Profile car captured time", "device_class": SensorDeviceClass.TIMESTAMP, "icon": "mdi:clock-check"},
-    "profile_state_report.instrument_cluster_time": {"name": "Profile instrument cluster time", "device_class": SensorDeviceClass.TIMESTAMP, "icon": "mdi:clock-outline"},
+    "min_temperature": {"name": "Battery module min temperature", "device_class": SensorDeviceClass.TEMPERATURE, "unit": UnitOfTemperature.CELSIUS, "state_class": SensorStateClass.MEASUREMENT, "category": EntityCategory.DIAGNOSTIC},
+    "max_temperature": {"name": "Battery module max temperature", "device_class": SensorDeviceClass.TEMPERATURE, "unit": UnitOfTemperature.CELSIUS, "state_class": SensorStateClass.MEASUREMENT, "category": EntityCategory.DIAGNOSTIC},
+    "car_captured_time": {"name": "Car captured time", "device_class": SensorDeviceClass.TIMESTAMP, "icon": "mdi:clock-check", "category": EntityCategory.DIAGNOSTIC},
+    "car_captured_utc_timestamp": {"name": "Car captured (UTC)", "device_class": SensorDeviceClass.TIMESTAMP, "icon": "mdi:clock-outline", "category": EntityCategory.DIAGNOSTIC},
+    "instrument_cluster_time": {"name": "Instrument cluster time", "device_class": SensorDeviceClass.TIMESTAMP, "icon": "mdi:clock-outline", "category": EntityCategory.DIAGNOSTIC},
+    "profile_state_report.car_captured_time": {"name": "Profile car captured time", "device_class": SensorDeviceClass.TIMESTAMP, "icon": "mdi:clock-check", "category": EntityCategory.DIAGNOSTIC},
+    "profile_state_report.instrument_cluster_time": {"name": "Profile instrument cluster time", "device_class": SensorDeviceClass.TIMESTAMP, "icon": "mdi:clock-outline", "category": EntityCategory.DIAGNOSTIC},
     "profile_state_report.next_charging_timer_information.estimated_start_time": {"name": "Next charge start (est.)", "device_class": SensorDeviceClass.TIMESTAMP, "icon": "mdi:clock-start"},
     "profile_state_report.next_charging_timer_information.estimated_finish_time": {"name": "Next charge finish (est.)", "device_class": SensorDeviceClass.TIMESTAMP, "icon": "mdi:clock-end"},
-    "battery_state_report.remaining_charging_time_complete": {"name": "Remaining charge time", "device_class": SensorDeviceClass.DURATION, "unit": UnitOfTime.SECONDS, "icon": "mdi:timer-sand"},
-    "remaining_climate_time": {"name": "Remaining climate time", "device_class": SensorDeviceClass.DURATION, "unit": UnitOfTime.SECONDS, "icon": "mdi:timer-sand"},
+    "battery_state_report.remaining_charging_time_complete": {"name": "Remaining charge time", "device_class": SensorDeviceClass.DURATION, "unit": UnitOfTime.SECONDS, "icon": "mdi:timer-sand", "category": EntityCategory.DIAGNOSTIC},
+    "remaining_climate_time": {"name": "Remaining climate time", "device_class": SensorDeviceClass.DURATION, "unit": UnitOfTime.SECONDS, "icon": "mdi:timer-sand", "category": EntityCategory.DIAGNOSTIC},
     "locked": {"name": "Locked", "icon": "mdi:lock"},
     "open": {"name": "Open", "icon": "mdi:car-door"},
-    "parking_brake": {"name": "Parking brake", "icon": "mdi:car-brake-parking"},
-    "parking_light_left": {"name": "Parking light left", "icon": "mdi:car-parking-lights"},
-    "parking_light_right": {"name": "Parking light right", "icon": "mdi:car-parking-lights"},
-    "window_heating_state": {"name": "Window heating", "icon": "mdi:car-defrost-rear"},
-    "additional_consumptions.residual_consumption": {"name": "Residual consumption", "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:flash"},
-    "additional_consumptions.interior_climatization_consumption": {"name": "Climatisation consumption", "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:fan"},
-    "slope_consumption_values.ascent_slope_consumption.physical_value": {"name": "Ascent slope consumption", "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:trending-up"},
-    "slope_consumption_values.descent_slope_consumption.physical_value": {"name": "Descent slope consumption", "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:trending-down"},
-    "energy_contents.current_energy_content.physical_value": {"name": "Current energy content", "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:battery-charging"},
-    "energy_contents.maximal_energy_content.physical_value": {"name": "Maximal energy content", "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:battery"},
-    "charging_state_report.charge_type": {"name": "Charge type", "icon": "mdi:ev-plug-type2"},
-    "charging_state_report.charge_mode": {"name": "Charge mode (report)", "icon": "mdi:cog"},
-    "charging_state_report.current_charge_state": {"name": "Charge state (report)", "icon": "mdi:ev-station"},
-    "settings.max_charge_current_ac": {"name": "Max AC charge current", "icon": "mdi:current-ac"},
-    "settings.charge_mode_selection": {"name": "Charge mode selection", "icon": "mdi:cog-outline"},
+    "parking_light_left": {"name": "Parking light left", "icon": "mdi:car-parking-lights", "category": EntityCategory.DIAGNOSTIC},
+    "parking_light_right": {"name": "Parking light right", "icon": "mdi:car-parking-lights", "category": EntityCategory.DIAGNOSTIC},
+    "window_heating_state": {"name": "Window heating", "icon": "mdi:car-defrost-rear", "category": EntityCategory.DIAGNOSTIC},
+    "additional_consumptions.residual_consumption": {"name": "Residual consumption", "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:flash", "category": EntityCategory.DIAGNOSTIC},
+    "additional_consumptions.interior_climatization_consumption": {"name": "Climatisation consumption", "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:fan", "category": EntityCategory.DIAGNOSTIC},
+    "slope_consumption_values.ascent_slope_consumption.physical_value": {"name": "Ascent slope consumption", "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:trending-up", "category": EntityCategory.DIAGNOSTIC},
+    "slope_consumption_values.descent_slope_consumption.physical_value": {"name": "Descent slope consumption", "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:trending-down", "category": EntityCategory.DIAGNOSTIC},
+    "energy_contents.current_energy_content.physical_value": {"name": "Current energy content", "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:battery-charging", "category": EntityCategory.DIAGNOSTIC},
+    "energy_contents.maximal_energy_content.physical_value": {"name": "Maximal energy content", "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:battery", "category": EntityCategory.DIAGNOSTIC},
+    "charging_state_report.charge_type": {"name": "Charge type", "icon": "mdi:ev-plug-type2", "category": EntityCategory.DIAGNOSTIC},
+    "charging_state_report.charge_mode": {"name": "Charge mode (report)", "icon": "mdi:cog", "category": EntityCategory.DIAGNOSTIC},
+    "charging_state_report.current_charge_state": {"name": "Charge state (report)", "icon": "mdi:ev-station", "category": EntityCategory.DIAGNOSTIC},
+    "settings.max_charge_current_ac": {"name": "Max AC charge current", "icon": "mdi:current-ac", "category": EntityCategory.DIAGNOSTIC},
+    "settings.charge_mode_selection": {"name": "Charge mode selection", "icon": "mdi:cog-outline", "category": EntityCategory.DIAGNOSTIC},
 }
 
 
@@ -360,6 +388,7 @@ class VolkswagenConnectValueSensor(_Base):
         self._key = key
         self._attr_unique_id = f"{vin}_{key}"
         meta = KNOWN_KEYS.get(key, {})
+        self._transform = meta.get("transform")
         self._attr_name = meta.get("name") or _prettify(key)
         if "device_class" in meta:
             self._attr_device_class = meta["device_class"]
@@ -369,6 +398,16 @@ class VolkswagenConnectValueSensor(_Base):
             self._attr_state_class = meta["state_class"]
         if "icon" in meta:
             self._attr_icon = meta["icon"]
+        if "category" in meta:
+            self._attr_entity_category = meta["category"]
+        elif not meta:
+            # Uncurated EU Data Act field: a raw code with no documented meaning
+            # and no curated label (see _prettify above). Keep it available
+            # (raw_value is still on the entity) but out of the way of the main
+            # device card, and off by default so a wide continuous-data payload
+            # doesn't flood new setups with unreadable sensors.
+            self._attr_entity_category = EntityCategory.DIAGNOSTIC
+            self._attr_entity_registry_enabled_default = False
         if not meta and self._is_numeric() and not _is_discrete_state_key(key):
             # Uncurated numeric fields would otherwise render as discrete
             # string states in HA (no graphs, no statistics) — see issue #12.
@@ -394,6 +433,8 @@ class VolkswagenConnectValueSensor(_Base):
             return str(val).lower()
         if isinstance(val, str):
             return _humanize_value(val)
+        if self._transform is not None:
+            return self._transform(val)
         return val
 
     @property


### PR DESCRIPTION
- Decode the EU Data Act per-door/window lock/open/safe state codes into real binary sensors instead of raw digits (see commit message for the 2/3 mapping caveat — cross-checked against a real vehicle and the sibling `vw_eu_data_act`/`TommiG1/HA_VAG-EU-Data-Act` project, not officially documented by VW).
- Drop the 32-bit "unset" sentinel (4294967295) some vehicles send for `mileage`.
- Fix `outside_temperature`'s deci-Kelvin scale (was showing e.g. 2991 instead of 25.9°C).
- Categorize uncurated/secondary fields as `diagnostic` (off the main device card by default) instead of cluttering it; curate a few more flat-schema fields (mileage, ranges, fuel level, window position %, oil level).
- Fix the "Data captured" sensor staying unknown forever on flat (pre-ID.x) payloads: derive it from each record's own `timestampUtc` instead of only searching for named fields that don't exist in that schema (confirmed against a real downloaded dataset from the portal).