### PR TITLE
Entity coverage + auth robustness improvements

### DIFF
--- a/custom_components/volkswagen_connect/__init__.py
+++ b/custom_components/volkswagen_connect/__init__.py
@@ -19,6 +19,7 @@ PLATFORMS: list[Platform] = [
     Platform.IMAGE,
     Platform.BUTTON,
     Platform.NUMBER,
+    Platform.CALENDAR,
 ]
 
 

--- a/custom_components/volkswagen_connect/__init__.py
+++ b/custom_components/volkswagen_connect/__init__.py
@@ -13,7 +13,13 @@ from .coordinator import VolkswagenConnectConfigEntry, VolkswagenConnectCoordina
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.IMAGE]
+PLATFORMS: list[Platform] = [
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+    Platform.IMAGE,
+    Platform.BUTTON,
+    Platform.NUMBER,
+]
 
 
 async def _migrate_binary_keys(

--- a/custom_components/volkswagen_connect/__init__.py
+++ b/custom_components/volkswagen_connect/__init__.py
@@ -20,6 +20,7 @@ PLATFORMS: list[Platform] = [
     Platform.BUTTON,
     Platform.NUMBER,
     Platform.CALENDAR,
+    Platform.DEVICE_TRACKER,
 ]
 
 

--- a/custom_components/volkswagen_connect/binary_sensor.py
+++ b/custom_components/volkswagen_connect/binary_sensor.py
@@ -16,6 +16,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -29,10 +30,13 @@ from .coordinator import VolkswagenConnectConfigEntry, VolkswagenConnectCoordina
 BINARY_KEYS: dict[str, dict[str, Any]] = {
     "locked": {"name": "Lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True},
     "open": {"name": "Open", "device_class": BinarySensorDeviceClass.OPENING},
-    "trunk.locked": {"name": "Trunk lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True},
+    # Detailed lock states for a secondary component (vs. the flat "locked"
+    # aggregate above) - diagnostic, matching how the reference vag_connect
+    # integration buckets its own "Coffre verrouillé"/"Capot verrouillé".
+    "trunk.locked": {"name": "Trunk lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "category": EntityCategory.DIAGNOSTIC},
     "trunk.open": {"name": "Trunk", "device_class": BinarySensorDeviceClass.OPENING},
-    "parking_brake": {"name": "Parking brake", "encoding": "onoff"},
-    "parking_lights": {"name": "Parking lights", "device_class": BinarySensorDeviceClass.LIGHT, "encoding": "lights"},
+    "parking_brake": {"name": "Parking brake", "encoding": "onoff", "category": EntityCategory.DIAGNOSTIC},
+    "parking_lights": {"name": "Parking lights", "device_class": BinarySensorDeviceClass.LIGHT, "encoding": "lights", "category": EntityCategory.DIAGNOSTIC},
     # Per-door/component state fields from the EU Data Act "access" cluster.
     # VW encodes these as 0=unsupported, 1=invalid, 2/3=the two real states
     # (which one is "2" depends on the field - see each comment below). This
@@ -42,15 +46,17 @@ BINARY_KEYS: dict[str, dict[str, Any]] = {
     # The raw code is still exposed as the `raw_value` attribute so you can
     # verify it yourself (open a door, watch it flip between 2 and 3).
     #
-    # Lock states: 2 = locked, 3 = unlocked.
-    "locked_state_front_left_door": {"name": "Front left door lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state"},
-    "locked_state_front_right_door": {"name": "Front right door lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state"},
+    # Lock states: 2 = locked, 3 = unlocked. Per-door/component detail beyond
+    # the flat "locked" aggregate above - diagnostic, same reasoning as
+    # trunk.locked/parking_brake above.
+    "locked_state_front_left_door": {"name": "Front left door lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    "locked_state_front_right_door": {"name": "Front right door lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
     # VW's own dataFieldName has a double underscore here (confirmed against
     # the actual delivered payload) - every other door uses a single one.
-    "locked_state__rear_left_door": {"name": "Rear left door lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state"},
-    "locked_state_rear_right_door": {"name": "Rear right door lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state"},
-    "locked_state_tailgate": {"name": "Tailgate lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state"},
-    "locked_state_front_engine_bonnet": {"name": "Bonnet lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state"},
+    "locked_state__rear_left_door": {"name": "Rear left door lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    "locked_state_rear_right_door": {"name": "Rear right door lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    "locked_state_tailgate": {"name": "Tailgate lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    "locked_state_front_engine_bonnet": {"name": "Bonnet lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
     # Open states: 2 = open, 3 = closed.
     "open_state_front_left_door": {"name": "Front left door", "device_class": BinarySensorDeviceClass.DOOR, "encoding": "state"},
     "open_state_front_right_door": {"name": "Front right door", "device_class": BinarySensorDeviceClass.DOOR, "encoding": "state"},
@@ -63,22 +69,29 @@ BINARY_KEYS: dict[str, dict[str, Any]] = {
     # produced "Dangereux" on every door/hood/tailgate while fully closed and
     # locked — so this field is inverted relative to the others: observed
     # behaviour is 2 = unsafe, 3 = safe (properly latched).
-    "safe_state_front_left_door": {"name": "Front left door latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state"},
-    "safe_state_front_right_door": {"name": "Front right door latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state"},
-    "safe_state_rear_left_door": {"name": "Rear left door latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state"},
-    "safe_state_rear_right_door": {"name": "Rear right door latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state"},
-    "safe_state_tailgate": {"name": "Tailgate latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state"},
-    "safe_state_front_engine_bonnet": {"name": "Bonnet latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state"},
-    # Window lifter / sunroof states: 2 = open, 3 = closed.
+    "safe_state_front_left_door": {"name": "Front left door latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    "safe_state_front_right_door": {"name": "Front right door latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    "safe_state_rear_left_door": {"name": "Rear left door latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    "safe_state_rear_right_door": {"name": "Rear right door latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    "safe_state_tailgate": {"name": "Tailgate latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    "safe_state_front_engine_bonnet": {"name": "Bonnet latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    # Window lifter / sunroof open-state: 2 = open, 3 = closed. Kept primary -
+    # the reference vag_connect integration shows its own window/sunroof
+    # open-state entities as plain primary sensors, not diagnostic (only the
+    # numeric *position%* sensors in sensor.py are diagnostic there).
     "state_front_left_door_window_lifter": {"name": "Front left window", "device_class": BinarySensorDeviceClass.WINDOW, "encoding": "state"},
     "state_front_right_door_window_lifter": {"name": "Front right window", "device_class": BinarySensorDeviceClass.WINDOW, "encoding": "state"},
     "state_rear_left_door_window_lifter": {"name": "Rear left window", "device_class": BinarySensorDeviceClass.WINDOW, "encoding": "state"},
     "state_rear_right_door_window_lifter": {"name": "Rear right window", "device_class": BinarySensorDeviceClass.WINDOW, "encoding": "state"},
     "state_sunroof_motor_hood_1": {"name": "Sunroof", "device_class": BinarySensorDeviceClass.WINDOW, "encoding": "state"},
-    "state_sunroof_motor_hood_3": {"name": "Sunroof motor 3", "encoding": "state"},
+    "state_sunroof_motor_hood_3": {"name": "Sunroof motor 3", "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    # Likely the ID.x/dotted counterpart of the flat "open_state_front_engine_bonnet"
+    # above (same pattern as mileage/odometer or outdoor/outside_temperature) - kept
+    # primary like its sibling rather than diagnostic, since only one of the two
+    # ever populates per vehicle.
     "state_of_hood": {"name": "Hood", "device_class": BinarySensorDeviceClass.OPENING, "encoding": "state"},
-    "state_service_hatch": {"name": "Service hatch (fuel/charge flap)", "device_class": BinarySensorDeviceClass.OPENING, "encoding": "state"},
-    "state_spoiler": {"name": "Spoiler", "device_class": BinarySensorDeviceClass.OPENING, "encoding": "state"},
+    "state_service_hatch": {"name": "Service hatch (fuel/charge flap)", "device_class": BinarySensorDeviceClass.OPENING, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    "state_spoiler": {"name": "Spoiler", "device_class": BinarySensorDeviceClass.OPENING, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
 }
 
 _TRUE = {"true", "1", "on", "yes"}
@@ -160,10 +173,19 @@ async def async_setup_entry(
     def _add_new() -> None:
         new: list[BinarySensorEntity] = []
         for vin, vehicle in (coordinator.data or {}).items():
-            for key in BINARY_KEYS:
-                if key in vehicle.values and (vin, key) not in known:
-                    known.add((vin, key))
-                    new.append(VolkswagenConnectBinarySensor(coordinator, vin, key))
+            for key, meta in BINARY_KEYS.items():
+                if (vin, key) in known or key not in vehicle.values:
+                    continue
+                decode = _DECODERS[meta.get("encoding", "bool")]
+                if decode(vehicle.values[key]) is None:
+                    # Key present but not yet a meaningful reading (VW's own
+                    # "0/1 = unsupported/invalid" placeholder) - skip creating
+                    # an entity that would just sit as permanently
+                    # Unavailable; re-checked on every update in case a later
+                    # delivery actually reports a real state.
+                    continue
+                known.add((vin, key))
+                new.append(VolkswagenConnectBinarySensor(coordinator, vin, key))
         if new:
             async_add_entities(new)
 
@@ -202,6 +224,8 @@ class VolkswagenConnectBinarySensor(
         self._attr_name = meta["name"]
         if "device_class" in meta:
             self._attr_device_class = meta["device_class"]
+        if "category" in meta:
+            self._attr_entity_category = meta["category"]
 
     @property
     def _vehicle(self) -> VehicleData | None:

--- a/custom_components/volkswagen_connect/button.py
+++ b/custom_components/volkswagen_connect/button.py
@@ -1,0 +1,101 @@
+"""Button platform: create the EU Data Act continuous data request.
+
+Today, enabling the 15-min EU Data Act feed requires the user to open the
+portal in a browser, sign in, link the vehicle and turn on a continuous
+data request by hand (see the config flow's setup description). This
+button calls the same "create data request" endpoint directly from HA for
+any vehicle whose data status is STATUS_NOT_CONFIGURED, removing that
+manual step.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, STATUS_NOT_CONFIGURED
+from .coordinator import VolkswagenConnectConfigEntry, VolkswagenConnectCoordinator, VehicleData
+from .eu_data_act import EuDataActAuthError
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: VolkswagenConnectConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    coordinator = entry.runtime_data
+    known: set[str] = set()
+
+    @callback
+    def _add_new() -> None:
+        due = [
+            vin
+            for vin, vehicle in (coordinator.data or {}).items()
+            if vin not in known and vehicle.status == STATUS_NOT_CONFIGURED
+        ]
+        known.update(due)
+        if due:
+            async_add_entities(
+                VolkswagenConnectDataRequestButton(coordinator, vin) for vin in due
+            )
+
+    _add_new()
+    entry.async_on_unload(coordinator.async_add_listener(_add_new))
+
+
+def _device(vehicle: VehicleData) -> DeviceInfo:
+    name = vehicle.info.get("nickName") or vehicle.info.get("licensePlate") or vehicle.vin
+    return DeviceInfo(
+        identifiers={(DOMAIN, vehicle.vin)},
+        manufacturer="Volkswagen",
+        name=name,
+        model=vehicle.info.get("nickName"),
+        serial_number=vehicle.vin,
+    )
+
+
+class VolkswagenConnectDataRequestButton(
+    CoordinatorEntity[VolkswagenConnectCoordinator], ButtonEntity
+):
+    """Create the EU Data Act continuous data request for this vehicle."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Enable EU Data Act request"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon = "mdi:database-plus"
+
+    def __init__(self, coordinator: VolkswagenConnectCoordinator, vin: str) -> None:
+        super().__init__(coordinator)
+        self._vin = vin
+        self._attr_unique_id = f"{vin}_data_request_button"
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        vehicle = (self.coordinator.data or {}).get(self._vin)
+        return _device(vehicle) if vehicle else None
+
+    async def async_press(self) -> None:
+        # A dead session here is not this button's job to fix - the next
+        # regular poll cycle will hit the same EuDataActAuthError and raise
+        # the usual Repairs issue/reauth flow. Just report and stop.
+        try:
+            created = await self.coordinator.client.create_data_request(self._vin)
+        except EuDataActAuthError as err:
+            _LOGGER.warning(
+                "Could not create an EU Data Act request for %s: %s", self._vin, err
+            )
+            return
+        if not created:
+            _LOGGER.warning(
+                "Could not create an EU Data Act request for %s; check the "
+                "debug log for the portal's response", self._vin,
+            )
+        await self.coordinator.async_request_refresh()

--- a/custom_components/volkswagen_connect/calendar.py
+++ b/custom_components/volkswagen_connect/calendar.py
@@ -1,0 +1,120 @@
+"""Calendar platform: upcoming service due-dates.
+
+Built purely from fields the coordinator already parses (inspection_due_days,
+oil_service_due_days, from website_portal.py::get_maintenance via
+coordinator._MAINTENANCE_MAP) - no new API calls. Both fields are the
+well-known VW "days until due" countdown (can go negative once overdue), so
+the event date is simply today + that many days.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN
+from .coordinator import VolkswagenConnectConfigEntry, VolkswagenConnectCoordinator, VehicleData
+
+# values key -> event summary
+_DUE_DATE_FIELDS = {
+    "inspection_due_days": "Inspection due",
+    "oil_service_due_days": "Oil service due",
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: VolkswagenConnectConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    coordinator = entry.runtime_data
+    known: set[str] = set()
+
+    @callback
+    def _add_new() -> None:
+        due = [
+            vin
+            for vin, vehicle in (coordinator.data or {}).items()
+            if vin not in known and any(k in vehicle.values for k in _DUE_DATE_FIELDS)
+        ]
+        known.update(due)
+        if due:
+            async_add_entities(
+                VolkswagenConnectServiceCalendar(coordinator, vin) for vin in due
+            )
+
+    _add_new()
+    entry.async_on_unload(coordinator.async_add_listener(_add_new))
+
+
+def _device(vehicle: VehicleData) -> DeviceInfo:
+    name = vehicle.info.get("nickName") or vehicle.info.get("licensePlate") or vehicle.vin
+    return DeviceInfo(
+        identifiers={(DOMAIN, vehicle.vin)},
+        manufacturer="Volkswagen",
+        name=name,
+        model=vehicle.info.get("nickName"),
+        serial_number=vehicle.vin,
+    )
+
+
+class VolkswagenConnectServiceCalendar(
+    CoordinatorEntity[VolkswagenConnectCoordinator], CalendarEntity
+):
+    """Upcoming inspection/oil-service due dates for one vehicle."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Service due"
+    _attr_icon = "mdi:wrench-clock"
+
+    def __init__(self, coordinator: VolkswagenConnectCoordinator, vin: str) -> None:
+        super().__init__(coordinator)
+        self._vin = vin
+        self._attr_unique_id = f"{vin}_service_calendar"
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        vehicle = (self.coordinator.data or {}).get(self._vin)
+        return _device(vehicle) if vehicle else None
+
+    def _events(self) -> list[CalendarEvent]:
+        vehicle = (self.coordinator.data or {}).get(self._vin)
+        if not vehicle:
+            return []
+        today = dt_util.now().date()
+        events: list[CalendarEvent] = []
+        for key, summary in _DUE_DATE_FIELDS.items():
+            days = vehicle.values.get(key)
+            if days is None:
+                continue
+            try:
+                due = today + timedelta(days=int(days))
+            except (TypeError, ValueError):
+                continue
+            events.append(
+                CalendarEvent(
+                    start=due,
+                    end=due + timedelta(days=1),
+                    summary=summary,
+                    uid=f"{self._vin}_{key}",
+                )
+            )
+        events.sort(key=lambda e: e.start)
+        return events
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        events = self._events()
+        return events[0] if events else None
+
+    async def async_get_events(
+        self, hass: HomeAssistant, start_date: datetime, end_date: datetime
+    ) -> list[CalendarEvent]:
+        lo, hi = start_date.date(), end_date.date()
+        return [e for e in self._events() if e.start < hi and e.end > lo]

--- a/custom_components/volkswagen_connect/const.py
+++ b/custom_components/volkswagen_connect/const.py
@@ -13,6 +13,9 @@ CONF_OTP = "otp"
 # Persisted website-portal session cookies (enables the optional authproxy
 # data source + silent refresh across restarts).
 CONF_WEBSITE_COOKIES = "website_cookies"
+# Persisted EU Data Act portal session cookies - without these, that client
+# re-logs-in (full password POST) on every HA restart.
+CONF_EU_DATA_ACT_COOKIES = "eu_data_act_cookies"
 # User-configurable poll interval, in minutes (config entry option). Falls
 # back to DEFAULT_SCAN_INTERVAL when unset.
 CONF_SCAN_INTERVAL = "scan_interval"

--- a/custom_components/volkswagen_connect/const.py
+++ b/custom_components/volkswagen_connect/const.py
@@ -13,11 +13,21 @@ CONF_OTP = "otp"
 # Persisted website-portal session cookies (enables the optional authproxy
 # data source + silent refresh across restarts).
 CONF_WEBSITE_COOKIES = "website_cookies"
+# User-configurable poll interval, in minutes (config entry option). Falls
+# back to DEFAULT_SCAN_INTERVAL when unset.
+CONF_SCAN_INTERVAL = "scan_interval"
 
 # Polling cadence. The portal delivers at most one dataset per 15 min, so there
 # is no value in polling faster; we add a small offset to avoid hammering on the
 # exact slot boundary.
 DEFAULT_SCAN_INTERVAL = timedelta(minutes=15)
+# The EU Data Act feed itself only refreshes every 15 min regardless, but the
+# website-portal channel (charging/warning lights/maintenance) is live - a
+# shorter interval still gets fresher portal data. The session-refresh
+# throttle in coordinator.py (_MIN_REFRESH_INTERVAL_S = 600s) is the actual
+# safety net against polling too aggressively, not this floor.
+MIN_SCAN_INTERVAL_MINUTES = 5
+MAX_SCAN_INTERVAL_MINUTES = 240
 
 # Vehicle "status" sensor states
 STATUS_OK = "ok"

--- a/custom_components/volkswagen_connect/coordinator.py
+++ b/custom_components/volkswagen_connect/coordinator.py
@@ -81,6 +81,11 @@ class VehicleData:
     image_urls: dict[str, str] = field(default_factory=dict)
     primary_image_view: str | None = None
     portal_ok: bool = False
+    # GPS - only populated if the authproxy actually exposes it (see
+    # website_portal.get_parking_position; unconfirmed for most accounts).
+    latitude: float | None = None
+    longitude: float | None = None
+    position_captured_at: str | None = None
 
 
 type VolkswagenConnectConfigEntry = ConfigEntry["VolkswagenConnectCoordinator"]
@@ -334,6 +339,20 @@ class VolkswagenConnectCoordinator(DataUpdateCoordinator[dict[str, VehicleData]]
                 # Vehicle-health warning lights + last lock/unlock command.
                 data.values.update(await self.portal.get_warning_lights(vin))
                 data.values.update(await self.portal.get_lock_history(vin))
+                # GPS position - experimental, most accounts likely 403/412 here
+                # (see get_parking_position's docstring); same non-fatal-degrade
+                # treatment as the charging 412 above, not an auth failure.
+                try:
+                    position = await self.portal.get_parking_position(vin)
+                except WebsitePortalAuthError as err:
+                    _LOGGER.debug(
+                        "No GPS position for %s (proxy likely doesn't expose it): %s",
+                        vin, err,
+                    )
+                    position = {}
+                data.latitude = position.get("latitude")
+                data.longitude = position.get("longitude")
+                data.position_captured_at = position.get("position_captured_at")
                 # Exterior images (public CDN URLs, served by the image platform).
                 # All views in one call; a side/profile shot is the primary "Image".
                 data.image_urls = await self.portal.get_vehicle_images(vin)

--- a/custom_components/volkswagen_connect/coordinator.py
+++ b/custom_components/volkswagen_connect/coordinator.py
@@ -105,13 +105,23 @@ _MAINTENANCE_MAP = {
 # raw EU Data Act duplicate is dropped. Only applied when the portal value is
 # actually present, so nothing disappears if the portal is unavailable.
 _PORTAL_DUPLICATES = {
-    "odometer": ("mileage.value",),
+    # Both the dotted (ID.x) and flat (pre-ID.x) EU Data Act mileage keys
+    # duplicate the portal's "odometer" - this Tiguan sends the flat one.
+    "odometer": ("mileage.value", "mileage"),
     "soc": ("battery_level_HV.value", "battery_state_report.soc"),
     "charge_power": ("battery_state_report.charge_power",),
     "charge_rate": ("battery_state_report.charge_rate",),
     "charging_state": ("charging_state_report.current_charge_state",),
     "charge_mode": ("charging_state_report.charge_mode",),
     "charge_time_remaining": ("battery_state_report.remaining_charging_time_complete",),
+    # EU Data Act's own raw maintenance-due fields duplicate _MAINTENANCE_MAP's
+    # portal-sourced values (confirmed live: same magnitude, opposite sign,
+    # no unit - entity id sensor.garage_tiguan_maintenance_interval_distance_
+    # until_inspection).
+    "inspection_due_km": ("maintenance_interval_distance_until_inspection",),
+    "inspection_due_days": ("maintenance_interval_time_until_inspection",),
+    "oil_service_due_km": ("maintenance_interval_distance_until_oil_change",),
+    "oil_service_due_days": ("maintenance_interval_time_until_oil_change",),
 }
 
 # EU Data Act fields carrying the moment the car *captured* the data (as opposed

--- a/custom_components/volkswagen_connect/coordinator.py
+++ b/custom_components/volkswagen_connect/coordinator.py
@@ -25,6 +25,7 @@ from homeassistant.util import dt as dt_util
 from .const import (
     CONF_BRAND,
     CONF_EMAIL,
+    CONF_EU_DATA_ACT_COOKIES,
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
     CONF_WEBSITE_COOKIES,
@@ -161,6 +162,9 @@ class VolkswagenConnectCoordinator(DataUpdateCoordinator[dict[str, VehicleData]]
             password=entry.data[CONF_PASSWORD],
             brand=entry.data.get(CONF_BRAND, DEFAULT_BRAND),
         )
+        eu_data_act_cookies = entry.data.get(CONF_EU_DATA_ACT_COOKIES)
+        if eu_data_act_cookies:
+            self.client.import_session(eu_data_act_cookies)
         # Website portal is optional: only active if we have a persisted session.
         self.portal: WebsitePortalClient | None = None
         cookies = entry.data.get(CONF_WEBSITE_COOKIES)
@@ -229,8 +233,10 @@ class VolkswagenConnectCoordinator(DataUpdateCoordinator[dict[str, VehicleData]]
         if self.portal is not None:
             await self._merge_portal(result)
         # Reached only if nothing above raised ConfigEntryAuthFailed - clear any
-        # stale auth Repair issue from a previous cycle.
+        # stale auth Repair issue from a previous cycle, and persist the EU Data
+        # Act session so it survives a restart instead of re-logging-in every time.
         repairs.clear_auth_issues(self.hass, self.entry.entry_id)
+        self._persist_eu_data_act_cookies()
         return result
 
     def _persist_portal_cookies(self) -> None:
@@ -240,6 +246,24 @@ class VolkswagenConnectCoordinator(DataUpdateCoordinator[dict[str, VehicleData]]
             self.entry,
             data={**self.entry.data, CONF_WEBSITE_COOKIES: self.portal.export_cookies()},
         )
+
+    def _persist_eu_data_act_cookies(self) -> None:
+        """Save the current EU Data Act session so it survives a restart.
+
+        Best-effort: called only once a cycle has already succeeded without
+        an auth failure, so there is never a dead session to accidentally
+        persist over a good one.
+        """
+        try:
+            self.hass.config_entries.async_update_entry(
+                self.entry,
+                data={
+                    **self.entry.data,
+                    CONF_EU_DATA_ACT_COOKIES: self.client.export_session(),
+                },
+            )
+        except Exception as err:  # noqa: BLE001 - never block a successful cycle on this
+            _LOGGER.debug("Could not persist EU Data Act session: %s", err)
 
     async def async_refresh_session(self, *, force: bool = False) -> None:
         """Roll the website-portal session (best-effort) and persist it.

--- a/custom_components/volkswagen_connect/coordinator.py
+++ b/custom_components/volkswagen_connect/coordinator.py
@@ -32,7 +32,7 @@ from .const import (
     STATUS_NOT_CONFIGURED,
     STATUS_OK,
 )
-from . import exceptions
+from . import exceptions, repairs
 from .eu_data_act import (
     DEFAULT_BRAND,
     EuDataActAuthError,
@@ -174,6 +174,7 @@ class VolkswagenConnectCoordinator(DataUpdateCoordinator[dict[str, VehicleData]]
             vehicles = await self.client.list_vehicles()
         except EuDataActAuthError as err:
             _log_auth_classification(err)
+            repairs.raise_issue_auth_required(self.hass, self.entry.entry_id, err.reason)
             raise ConfigEntryAuthFailed(str(err)) from err
         except EuDataActError as err:
             # The EU Data Act backend is flaky; with a portal session available
@@ -215,6 +216,7 @@ class VolkswagenConnectCoordinator(DataUpdateCoordinator[dict[str, VehicleData]]
                 data.status = STATUS_NOT_CONFIGURED
             except EuDataActAuthError as err:
                 _log_auth_classification(err)
+                repairs.raise_issue_auth_required(self.hass, self.entry.entry_id, err.reason)
                 raise ConfigEntryAuthFailed(str(err)) from err
             except EuDataActError as err:
                 _LOGGER.warning("EU Data Act: %s update failed: %s", vin, err)
@@ -222,6 +224,9 @@ class VolkswagenConnectCoordinator(DataUpdateCoordinator[dict[str, VehicleData]]
 
         if self.portal is not None:
             await self._merge_portal(result)
+        # Reached only if nothing above raised ConfigEntryAuthFailed - clear any
+        # stale auth Repair issue from a previous cycle.
+        repairs.clear_auth_issues(self.hass, self.entry.entry_id)
         return result
 
     def _persist_portal_cookies(self) -> None:
@@ -333,6 +338,9 @@ class VolkswagenConnectCoordinator(DataUpdateCoordinator[dict[str, VehicleData]]
             # Surface it as a proper reauth: HA shows a "Reauthentication
             # required" repair instead of entities silently going stale (#13).
             _log_auth_classification(auth_failed)
+            repairs.raise_issue_auth_required(
+                self.hass, self.entry.entry_id, auth_failed.reason or "invalid_auth"
+            )
             raise ConfigEntryAuthFailed(
                 f"Volkswagen session expired ({auth_failed}); please log in again"
             ) from auth_failed

--- a/custom_components/volkswagen_connect/coordinator.py
+++ b/custom_components/volkswagen_connect/coordinator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass, field
+from datetime import timedelta
 from typing import Any
 
 import aiohttp
@@ -25,6 +26,7 @@ from .const import (
     CONF_BRAND,
     CONF_EMAIL,
     CONF_PASSWORD,
+    CONF_SCAN_INTERVAL,
     CONF_WEBSITE_COOKIES,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
@@ -147,7 +149,9 @@ class VolkswagenConnectCoordinator(DataUpdateCoordinator[dict[str, VehicleData]]
     """Polls the website authproxy (and optionally the EU Data Act portal)."""
 
     def __init__(self, hass: HomeAssistant, entry: VolkswagenConnectConfigEntry) -> None:
-        super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=DEFAULT_SCAN_INTERVAL)
+        minutes = entry.options.get(CONF_SCAN_INTERVAL)
+        interval = timedelta(minutes=minutes) if minutes else DEFAULT_SCAN_INTERVAL
+        super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=interval)
         self.entry = entry
         # Monotonic timestamp of the last portal session refresh (None = never).
         self._last_refresh: float | None = None

--- a/custom_components/volkswagen_connect/coordinator.py
+++ b/custom_components/volkswagen_connect/coordinator.py
@@ -32,6 +32,7 @@ from .const import (
     STATUS_NOT_CONFIGURED,
     STATUS_OK,
 )
+from . import exceptions
 from .eu_data_act import (
     DEFAULT_BRAND,
     EuDataActAuthError,
@@ -131,6 +132,17 @@ def _best_captured_at(values: dict[str, Any]) -> str | None:
     return best.isoformat() if best else None
 
 
+def _log_auth_classification(err: EuDataActAuthError | WebsitePortalAuthError) -> None:
+    """Log the typed classification of an auth failure before it becomes a reauth.
+
+    Doesn't change behaviour today - every classification still surfaces as
+    ConfigEntryAuthFailed - but gives a Repairs flow (a future addition)
+    something precise to key off instead of a free-form message string.
+    """
+    kind = exceptions.classify(err.reason)
+    _LOGGER.info("Auth failure classified as %s: %s", kind.__name__, err)
+
+
 class VolkswagenConnectCoordinator(DataUpdateCoordinator[dict[str, VehicleData]]):
     """Polls the website authproxy (and optionally the EU Data Act portal)."""
 
@@ -161,6 +173,7 @@ class VolkswagenConnectCoordinator(DataUpdateCoordinator[dict[str, VehicleData]]
         try:
             vehicles = await self.client.list_vehicles()
         except EuDataActAuthError as err:
+            _log_auth_classification(err)
             raise ConfigEntryAuthFailed(str(err)) from err
         except EuDataActError as err:
             # The EU Data Act backend is flaky; with a portal session available
@@ -201,6 +214,7 @@ class VolkswagenConnectCoordinator(DataUpdateCoordinator[dict[str, VehicleData]]
             except EuDataActNotConfigured:
                 data.status = STATUS_NOT_CONFIGURED
             except EuDataActAuthError as err:
+                _log_auth_classification(err)
                 raise ConfigEntryAuthFailed(str(err)) from err
             except EuDataActError as err:
                 _LOGGER.warning("EU Data Act: %s update failed: %s", vin, err)
@@ -318,6 +332,7 @@ class VolkswagenConnectCoordinator(DataUpdateCoordinator[dict[str, VehicleData]]
         if auth_failed is not None:
             # Surface it as a proper reauth: HA shows a "Reauthentication
             # required" repair instead of entities silently going stale (#13).
+            _log_auth_classification(auth_failed)
             raise ConfigEntryAuthFailed(
                 f"Volkswagen session expired ({auth_failed}); please log in again"
             ) from auth_failed

--- a/custom_components/volkswagen_connect/device_tracker.py
+++ b/custom_components/volkswagen_connect/device_tracker.py
@@ -1,0 +1,95 @@
+"""Device tracker platform: last-known GPS position, where available.
+
+EXPERIMENTAL: website_portal.get_parking_position hits a proxy path VW's own
+myvolkswagen.de site never uses (it has no "find my car" map), so most
+accounts will simply never populate latitude/longitude - this platform then
+never spawns an entity for that vehicle, which is the correct, silent
+degrade (see coordinator._merge_portal).
+"""
+
+from __future__ import annotations
+
+from homeassistant.components.device_tracker import SourceType, TrackerEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import VolkswagenConnectConfigEntry, VolkswagenConnectCoordinator, VehicleData
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: VolkswagenConnectConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    coordinator = entry.runtime_data
+    known: set[str] = set()
+
+    @callback
+    def _add_new() -> None:
+        due = [
+            vin
+            for vin, vehicle in (coordinator.data or {}).items()
+            if vin not in known and vehicle.latitude is not None
+        ]
+        known.update(due)
+        if due:
+            async_add_entities(
+                VolkswagenConnectTracker(coordinator, vin) for vin in due
+            )
+
+    _add_new()
+    entry.async_on_unload(coordinator.async_add_listener(_add_new))
+
+
+def _device(vehicle: VehicleData) -> DeviceInfo:
+    name = vehicle.info.get("nickName") or vehicle.info.get("licensePlate") or vehicle.vin
+    return DeviceInfo(
+        identifiers={(DOMAIN, vehicle.vin)},
+        manufacturer="Volkswagen",
+        name=name,
+        model=vehicle.info.get("nickName"),
+        serial_number=vehicle.vin,
+    )
+
+
+class VolkswagenConnectTracker(CoordinatorEntity[VolkswagenConnectCoordinator], TrackerEntity):
+    """Last-known parked position for one vehicle."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Location"
+    _attr_icon = "mdi:map-marker"
+    _attr_source_type = SourceType.GPS
+
+    def __init__(self, coordinator: VolkswagenConnectCoordinator, vin: str) -> None:
+        super().__init__(coordinator)
+        self._vin = vin
+        self._attr_unique_id = f"{vin}_location"
+
+    @property
+    def _vehicle(self) -> VehicleData | None:
+        return (self.coordinator.data or {}).get(self._vin)
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        v = self._vehicle
+        return _device(v) if v else None
+
+    @property
+    def latitude(self) -> float | None:
+        v = self._vehicle
+        return v.latitude if v else None
+
+    @property
+    def longitude(self) -> float | None:
+        v = self._vehicle
+        return v.longitude if v else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str] | None:
+        v = self._vehicle
+        if not v or not v.position_captured_at:
+            return None
+        return {"position_captured_at": v.position_captured_at}

--- a/custom_components/volkswagen_connect/eu_data_act.py
+++ b/custom_components/volkswagen_connect/eu_data_act.py
@@ -293,6 +293,14 @@ def _extract_values(raw: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
                 out[name] = _coerce(r.get("value"))
         elif isinstance(doc, (dict, list)):
             out.update(flatten(doc))
+    # flatten()'s generic fallback (used for docs that aren't shaped as the
+    # expected records list) has no notion of _SKIP_FIELDS, so an envelope
+    # field like "echo" can leak through under a dotted path (e.g.
+    # "some.prefix.echo") instead of the bare name the per-record loop above
+    # already filters. Catch that here, matched on the final path segment.
+    for key in list(out):
+        if key.rsplit(".", 1)[-1] in _SKIP_FIELDS:
+            del out[key]
     return out, latest_ts
 
 

--- a/custom_components/volkswagen_connect/eu_data_act.py
+++ b/custom_components/volkswagen_connect/eu_data_act.py
@@ -31,11 +31,13 @@ import re
 import secrets
 import zipfile
 from datetime import datetime, timedelta, timezone
+from http.cookies import SimpleCookie
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
 import aiohttp
 from bs4 import BeautifulSoup
+from yarl import URL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -315,6 +317,45 @@ class EuDataActClient:
         self._country = country
         self._language = language
         self._logged_in = False
+
+    # -- session persistence -------------------------------------------------
+
+    def export_session(self) -> list[dict[str, str]]:
+        """Persist cookies as (domain, key, value) triples.
+
+        Same shape as WebsitePortalClient.export_cookies() (this client also
+        spans two hosts - the portal and identity.vwgroup.io during login -
+        so a bare key isn't unique either).
+        """
+        seen: dict[tuple[str, str], str] = {}
+        for cookie in self._session.cookie_jar:
+            domain = cookie["domain"] or ""
+            seen[(domain, cookie.key)] = cookie.value
+        return [{"domain": d, "key": k, "value": v} for (d, k), v in seen.items()]
+
+    def import_session(self, data: list[dict[str, str]]) -> None:
+        """Restore a previously exported session.
+
+        Optimistically marks the client as logged in - if the session turned
+        out to be dead, the existing 401/AEM-5xx retry-and-relogin logic in
+        _request() catches it on the very first real call, so trusting a
+        stale session here is safe, not a new failure mode.
+        """
+        restored = False
+        for c in data:
+            key = c.get("key")
+            domain = (c.get("domain") or "").strip()
+            if not key or not domain:
+                continue
+            sc: SimpleCookie = SimpleCookie()
+            sc[key] = c.get("value", "")
+            sc[key]["path"] = "/"
+            if domain.startswith("."):
+                sc[key]["domain"] = domain
+            self._session.cookie_jar.update_cookies(sc, URL(f"https://{domain.lstrip('.')}/"))
+            restored = True
+        if restored:
+            self._logged_in = True
 
     # -- auth ---------------------------------------------------------------
 

--- a/custom_components/volkswagen_connect/eu_data_act.py
+++ b/custom_components/volkswagen_connect/eu_data_act.py
@@ -28,7 +28,9 @@ import io
 import json
 import logging
 import re
+import secrets
 import zipfile
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
@@ -58,9 +60,30 @@ DEFAULT_BRAND = "VOLKSWAGEN_PASSENGER_CARS"
 VEHICLES_PATH = "/proxy_api/consent/me/vehicles"
 RELATION_PATH = "/proxy_api/vum/v2/users/me/relations/{vin}"
 METADATA_PATH = "/proxy_api/euda-apim/datarequest/vehicles/{vin}/metadata/partial"
+CUSTOM_REQUEST_POST_PATH = "/proxy_api/euda-apim/datarequest/vehicles/{vin}/requests/partial"
 LIST_PATH = "/proxy_api/euda-apim/datadelivery/vehicles/{vin}/{identifier}/list"
 DOWNLOAD_PATH = "/proxy_api/euda-apim/datadelivery/vehicles/{vin}/{identifier}/download"
 NO_CONTENT_SUFFIX = "_no_content_found.zip"
+
+# The portal runs two independent auth layers on one host: /proxy_api/* (the
+# APIM reverse proxy our login authenticates against, used by every read
+# above) and /libs/granite/*, /services/*, /content/* (the AEM publish tier
+# the CSRF token needed for a *write* - creating a data request - lives on).
+# A session can be perfectly valid for reads and anonymous at this layer,
+# which shows up as HTTP 200 with an empty {} body; loading the portal page
+# once (as a browser does when the user opens it) can revive it.
+CSRF_TOKEN_PATH = "/libs/granite/csrf/token.json"
+AEM_SESSION_PAGE_PATH = "/de/en/user.html"
+
+# Canonical Data Clusters, spelled exactly as the portal UI sends them.
+DEFAULT_DATA_CLUSTERS = (
+    "All Data",
+    "Charging",
+    "Driving Behaviour",
+    "Maintenance Related Information",
+    "Parking Data",
+    "Vehicle Warning Lights",
+)
 
 USER_AGENT = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
@@ -427,6 +450,142 @@ class EuDataActClient:
         if isinstance(meta, list):
             meta = meta[0] if meta else {}
         return meta
+
+    async def _csrf_get(self) -> str | None:
+        try:
+            async with self._session.get(
+                BASE_URL + CSRF_TOKEN_PATH,
+                headers={"User-Agent": USER_AGENT, "Accept": "application/json"},
+            ) as resp:
+                if resp.status != 200:
+                    return None
+                data = await resp.json(content_type=None)
+        except (aiohttp.ClientError, TimeoutError, json.JSONDecodeError) as err:
+            _LOGGER.debug("EU Data Act CSRF fetch failed: %s", err)
+            return None
+        if isinstance(data, dict):
+            token = data.get("token") or data.get("csrfToken")
+            if isinstance(token, str) and token:
+                return token
+        return None
+
+    async def _fetch_csrf_token(self) -> str | None:
+        """CSRF token for the AEM layer, needed to POST a new data request."""
+        token = await self._csrf_get()
+        if token:
+            return token
+        try:
+            await self._session.get(
+                BASE_URL + AEM_SESSION_PAGE_PATH, headers={"User-Agent": USER_AGENT}
+            )
+        except aiohttp.ClientError as err:
+            _LOGGER.debug("EU Data Act AEM revive GET failed: %s", err)
+            return None
+        return await self._csrf_get()
+
+    async def create_data_request(
+        self,
+        vin: str,
+        *,
+        name: str = "Home Assistant",
+        data_clusters: tuple[str, ...] | None = None,
+    ) -> bool:
+        """Create the active 15-min Custom Data Request for ``vin``.
+
+        Should only be called after ``get_metadata`` raised
+        ``EuDataActNotConfigured`` - the portal allows at most one active
+        request per VIN and rejects a second concurrent one with 4xx.
+
+        Tries "No Expiry" first (what the portal's own UI sends), falling
+        back to a finite "One Month" window if that shape is rejected or
+        silently accepted-but-inert (a 2xx that doesn't show up on
+        readback) - asking for a shorter feed is far better than ending up
+        with no feed at all. Returns True once a request is confirmed
+        active via readback, False otherwise; raises EuDataActAuthError if
+        the session itself is gone.
+        """
+        await self._ensure_login()
+        csrf = await self._fetch_csrf_token()
+        if not csrf:
+            _LOGGER.debug("create_data_request: no CSRF token, aborting")
+            return False
+
+        identifier = secrets.token_hex(16)
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+        clusters = list(data_clusters or DEFAULT_DATA_CLUSTERS)
+
+        def _body(duration: str, days: int | None) -> dict[str, Any]:
+            body: dict[str, Any] = {
+                "Name": name,
+                "Identifier": identifier,
+                "Frequency": "15mins",
+                "Duration": duration,
+                "StartDate": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "DataClusters": clusters,
+                "EmailFrequency": "No notification",
+                "LastNotificationDate": None,
+            }
+            if days is not None:
+                end = (now + timedelta(days=days)).replace(hour=23, minute=59, second=59)
+                body["EndDate"] = end.strftime("%Y-%m-%dT%H:%M:%SZ")
+            return body
+
+        attempts: list[tuple[str, int | None]] = [("No Expiry", None), ("One Month", 31)]
+        url = BASE_URL + CUSTOM_REQUEST_POST_PATH.format(vin=vin)
+        for index, (duration, days) in enumerate(attempts):
+            last = index == len(attempts) - 1
+            try:
+                async with self._session.post(
+                    url,
+                    json=_body(duration, days),
+                    headers={
+                        "User-Agent": USER_AGENT,
+                        "Accept": "application/json",
+                        "Content-Type": "application/json",
+                        "CSRF-Token": csrf,
+                    },
+                ) as resp:
+                    if resp.status == 401:
+                        raise EuDataActAuthError("requests/partial: session expired")
+                    if resp.status in (200, 201, 202):
+                        try:
+                            meta = await self.get_metadata(vin)
+                        except EuDataActNotConfigured:
+                            meta = {}
+                        if meta.get("Identifier"):
+                            _LOGGER.info(
+                                "EU Data Act data request created for %s (Duration=%s)",
+                                vin, duration,
+                            )
+                            return True
+                        if not last:
+                            _LOGGER.info(
+                                "create_data_request: Duration=%r returned %s but no "
+                                "active request appeared on readback - retrying with %r",
+                                duration, resp.status, attempts[index + 1][0],
+                            )
+                            continue
+                        _LOGGER.warning(
+                            "create_data_request: created (HTTP %s) but no active "
+                            "request appeared for %s", resp.status, vin,
+                        )
+                        return False
+                    text = await resp.text()
+                    if not last:
+                        _LOGGER.info(
+                            "create_data_request: portal rejected Duration=%r (HTTP %s), "
+                            "retrying with %r: %s",
+                            duration, resp.status, attempts[index + 1][0], text[:200],
+                        )
+                        continue
+                    _LOGGER.warning(
+                        "create_data_request HTTP %s for %s: %s", resp.status, vin, text[:300]
+                    )
+                    return False
+            except (aiohttp.ClientError, TimeoutError) as err:
+                _LOGGER.debug("create_data_request failed: %s", err)
+                return False
+        return False  # pragma: no cover - loop always returns above
 
     async def list_datasets(self, vin: str, identifier: str) -> list[dict]:
         data = await self._get_json(

--- a/custom_components/volkswagen_connect/exceptions.py
+++ b/custom_components/volkswagen_connect/exceptions.py
@@ -1,0 +1,71 @@
+"""Typed classification for the auth failures raised by the two clients.
+
+``EuDataActClient``/``WebsitePortalClient`` stay Home-Assistant-independent and
+keep their own lightweight exceptions (``EuDataActAuthError``,
+``WebsitePortalAuthError``) with a free-form ``reason`` string — that string
+already doubles as a config-flow error key (see ``strings.json``). This module
+adds a small classification layer on top of that same vocabulary: a coarse
+split between "this needs the user to do something" and "this is transient,
+don't nag for a password", which the coordinator (and, later, a Repairs flow)
+can act on without hardcoding the reason-string list themselves.
+"""
+
+from __future__ import annotations
+
+
+class VolkswagenConnectError(Exception):
+    """Base class for every typed classification in this module."""
+
+
+class AuthenticationError(VolkswagenConnectError):
+    """Terminal: wrong credentials, needs a fresh login."""
+
+
+class UpstreamUnavailableError(VolkswagenConnectError):
+    """Transient: VW's backend is down/erroring - must NOT trigger reauth."""
+
+
+class RateLimitError(AuthenticationError):
+    """Too many login attempts; VW is throttling this account."""
+
+
+class TwoFactorRequiredError(AuthenticationError):
+    """A second factor is required to complete login.
+
+    Not reachable via ``classify()`` yet - the website portal's OTP challenge
+    is already handled as its own config-flow step rather than a ``reason``
+    string, and EU Data Act has not been observed to require one. Kept here
+    so a future login path (or a finer OTP-failure reason) has somewhere to
+    plug in without inventing a parallel hierarchy.
+    """
+
+
+class EmailTwoFactorRequiredError(TwoFactorRequiredError):
+    """The second factor is an emailed one-time code."""
+
+
+class PortalInteractionRequiredError(AuthenticationError):
+    """The account needs a manual step on VW's own site (consent, vehicle
+    linking, enabling a data request, ...) - not a wrong password."""
+
+
+# Maps the free-form ``reason`` strings already used by EuDataActAuthError /
+# WebsitePortalAuthError (which double as config-flow error keys, see
+# strings.json) to a typed class above.
+REASON_TO_EXCEPTION: dict[str, type[VolkswagenConnectError]] = {
+    "invalid_auth": AuthenticationError,
+    "account_locked": AuthenticationError,
+    "throttled": RateLimitError,
+    "not_authorised": PortalInteractionRequiredError,
+    "cannot_connect": UpstreamUnavailableError,
+}
+
+
+def classify(reason: str) -> type[VolkswagenConnectError]:
+    """Return the typed exception class for a config-flow error-key reason.
+
+    Unknown/empty reasons default to ``AuthenticationError`` - safer to treat
+    an unclassified auth failure as terminal (ask the user to log in again)
+    than to silently swallow it as transient.
+    """
+    return REASON_TO_EXCEPTION.get(reason, AuthenticationError)

--- a/custom_components/volkswagen_connect/image.py
+++ b/custom_components/volkswagen_connect/image.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from homeassistant.components.image import ImageEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
@@ -83,6 +84,7 @@ class VolkswagenConnectVehicleImage(CoordinatorEntity[VolkswagenConnectCoordinat
             self._attr_unique_id = f"{vin}_image_{view}"
             self._attr_name = f"Image {view.replace('_', ' ')}"
             self._attr_entity_registry_enabled_default = False
+            self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._current_url: str | None = None
         url = self._url
         if url:

--- a/custom_components/volkswagen_connect/number.py
+++ b/custom_components/volkswagen_connect/number.py
@@ -1,0 +1,72 @@
+"""Number platform: a single account-level poll-interval slider.
+
+One entity per config entry (not per vehicle) - it controls the shared
+coordinator's polling cadence. Changing it takes effect immediately (no
+integration reload) and is persisted to the config entry's options so it
+survives a restart.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.const import EntityCategory, UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import (
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    MAX_SCAN_INTERVAL_MINUTES,
+    MIN_SCAN_INTERVAL_MINUTES,
+)
+from .coordinator import VolkswagenConnectConfigEntry, VolkswagenConnectCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: VolkswagenConnectConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    async_add_entities([VolkswagenConnectScanIntervalNumber(entry)])
+
+
+class VolkswagenConnectScanIntervalNumber(NumberEntity):
+    """How often (in minutes) the coordinator polls Volkswagen."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Poll interval"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon = "mdi:timer-cog-outline"
+    _attr_native_unit_of_measurement = UnitOfTime.MINUTES
+    _attr_native_min_value = MIN_SCAN_INTERVAL_MINUTES
+    _attr_native_max_value = MAX_SCAN_INTERVAL_MINUTES
+    _attr_native_step = 5
+
+    def __init__(self, entry: VolkswagenConnectConfigEntry) -> None:
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_scan_interval"
+        default_minutes = int(DEFAULT_SCAN_INTERVAL.total_seconds() / 60)
+        self._attr_native_value = entry.options.get(CONF_SCAN_INTERVAL, default_minutes)
+        # Not tied to any one vehicle - it controls the shared coordinator - so
+        # it gets its own lightweight service-level device instead of being an
+        # orphan entity with no device page.
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            name="Volkswagen Connect",
+            manufacturer="Volkswagen",
+            entry_type=DeviceEntryType.SERVICE,
+        )
+
+    async def async_set_native_value(self, value: float) -> None:
+        minutes = int(value)
+        coordinator: VolkswagenConnectCoordinator = self._entry.runtime_data
+        coordinator.update_interval = timedelta(minutes=minutes)
+        self._attr_native_value = minutes
+        self.async_write_ha_state()
+        self.hass.config_entries.async_update_entry(
+            self._entry, options={**self._entry.options, CONF_SCAN_INTERVAL: minutes}
+        )

--- a/custom_components/volkswagen_connect/repairs.py
+++ b/custom_components/volkswagen_connect/repairs.py
@@ -1,0 +1,107 @@
+"""HA Repairs integration for auth failures.
+
+Without this, a failing login only shows up as a log line plus entities
+quietly going unavailable, and the generic "Reauthentication required"
+notice HA shows for a bare ConfigEntryAuthFailed. This surfaces a persistent
+issue under Settings -> System -> Repairs, worded for the actual reason
+(``exceptions.classify``'s vocabulary - the same ``reason`` strings already
+used as config-flow error keys, see strings.json's ``config.error`` block),
+and gives the fixable ones a "Repair" button that jumps straight into the
+reauth step instead of making the user find it themselves.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant import data_entry_flow
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.issue_registry as ir
+
+from .const import DOMAIN
+from .eu_data_act import BASE_URL
+
+# Every reason we currently classify is resolved by (re)running the reauth
+# step - even "not_authorised", whose actual fix is a manual step in a
+# browser, still ends with the user re-entering their password here so the
+# entry is validated again afterwards.
+_FIXABLE_REASONS: dict[str, str] = {
+    "invalid_auth": "reauth",
+    "account_locked": "reauth",
+    "throttled": "reauth",
+    "not_authorised": "reauth",
+}
+
+# Reasons with a translation entry under "issues" in strings.json. Anything
+# else (a reason we haven't classified yet) falls back to the generic
+# "auth_failed" translation instead of showing a raw, untranslated key.
+_KNOWN_REASONS = (*_FIXABLE_REASONS, "cannot_connect")
+
+
+def _learn_more_url(reason: str) -> str | None:
+    """A deep link worth offering for this specific reason, if any."""
+    if reason == "not_authorised":
+        return f"{BASE_URL}/"
+    return None
+
+
+def raise_issue_auth_required(hass: HomeAssistant, entry_id: str, reason: str) -> None:
+    """Create (or refresh) a Repair issue for an auth failure on this entry.
+
+    Idempotent: HA de-dupes by issue id, so calling this again on every
+    failed poll just keeps the existing issue's timestamp fresh.
+    """
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        f"{entry_id}_{reason}",
+        is_fixable=reason in _FIXABLE_REASONS,
+        is_persistent=False,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key=reason if reason in _KNOWN_REASONS else "auth_failed",
+        learn_more_url=_learn_more_url(reason),
+        data={"entry_id": entry_id, "reason": reason},
+    )
+
+
+def clear_auth_issues(hass: HomeAssistant, entry_id: str) -> None:
+    """Delete every possible auth Repair issue for this entry after a success."""
+    for reason in (*_KNOWN_REASONS, "auth_failed"):
+        ir.async_delete_issue(hass, DOMAIN, f"{entry_id}_{reason}")
+
+
+class _AuthRepairFlow(RepairsFlow):
+    """Delegates to the reauth config-flow step so the user fixes it in place."""
+
+    def __init__(self, entry_id: str, reason: str) -> None:
+        self._entry_id = entry_id
+        self._reason = reason
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> data_entry_flow.FlowResult:
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> data_entry_flow.FlowResult:
+        if user_input is None:
+            return self.async_show_form(
+                step_id="confirm",
+                description_placeholders={"reason": self._reason},
+            )
+        flow_step = _FIXABLE_REASONS.get(self._reason, "reauth")
+        await self.hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": flow_step, "entry_id": self._entry_id}
+        )
+        return self.async_create_entry(title="", data={})
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant, issue_id: str, data: dict[str, Any] | None
+) -> RepairsFlow:
+    """HA RepairsFlow factory, called when the user clicks "Repair"."""
+    entry_id = (data or {}).get("entry_id", "")
+    reason = (data or {}).get("reason", "auth_failed")
+    return _AuthRepairFlow(entry_id, reason)

--- a/custom_components/volkswagen_connect/sensor.py
+++ b/custom_components/volkswagen_connect/sensor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import re
+from datetime import timedelta
 from typing import Any
 
 from homeassistant.components.sensor import (
@@ -179,6 +180,16 @@ KNOWN_KEYS: dict[str, dict[str, Any]] = {
 }
 
 
+# "days until due" countdown fields (already exposed as plain-number sensors
+# via KNOWN_KEYS) that also get a companion absolute-date sensor - an actual
+# calendar date is easier to read at a glance than a day count, and mirrors
+# what other VW Group integrations expose for the same signal.
+_DUE_DATE_SOURCES: dict[str, tuple[str, str]] = {
+    "inspection_due_days": ("Inspection due date", "mdi:wrench-clock"),
+    "oil_service_due_days": ("Oil service due date", "mdi:oil"),
+}
+
+
 # Leading category prefixes on VW enum values, stripped before humanising so
 # CHARGE_STATE_NOT_READY_FOR_CHARGING -> "Not ready for charging". Longest /
 # most-specific first (CHARGE_MODE_SELECTION_ must beat CHARGE_MODE_).
@@ -280,6 +291,13 @@ async def async_setup_entry(
                 known.add(status_key)
                 new.append(VolkswagenConnectStatusSensor(coordinator, vin))
                 new.append(VolkswagenConnectCapturedSensor(coordinator, vin))
+            for source_key, (name, icon) in _DUE_DATE_SOURCES.items():
+                due_key = (vin, f"__due_date_{source_key}__")
+                if due_key not in known and source_key in vehicle.values:
+                    known.add(due_key)
+                    new.append(
+                        VolkswagenConnectDueDateSensor(coordinator, vin, source_key, name, icon)
+                    )
             for key in vehicle.values:
                 vk = (vin, key)
                 if vk in known or key in BINARY_KEYS:
@@ -401,6 +419,45 @@ class VolkswagenConnectCapturedSensor(_Base):
         if not v or not v.captured_at:
             return None
         return dt_util.parse_datetime(v.captured_at)
+
+
+class VolkswagenConnectDueDateSensor(_Base):
+    """Absolute calendar date derived from a "days until due" countdown.
+
+    inspection_due_days/oil_service_due_days are VW's well-known "days
+    remaining" counters (can go negative once overdue) - this turns that
+    into an actual date, easier to read at a glance than a raw day count.
+    """
+
+    _attr_device_class = SensorDeviceClass.DATE
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator: VolkswagenConnectCoordinator,
+        vin: str,
+        source_key: str,
+        name: str,
+        icon: str,
+    ) -> None:
+        super().__init__(coordinator, vin)
+        self._source_key = source_key
+        self._attr_unique_id = f"{vin}_{source_key}_date"
+        self._attr_name = name
+        self._attr_icon = icon
+
+    @property
+    def native_value(self) -> StateType:
+        v = self._vehicle
+        if not v:
+            return None
+        days = v.values.get(self._source_key)
+        if days is None:
+            return None
+        try:
+            return dt_util.now().date() + timedelta(days=int(days))
+        except (TypeError, ValueError):
+            return None
 
 
 class VolkswagenConnectValueSensor(_Base):

--- a/custom_components/volkswagen_connect/sensor.py
+++ b/custom_components/volkswagen_connect/sensor.py
@@ -105,18 +105,21 @@ KNOWN_KEYS: dict[str, dict[str, Any]] = {
     # sibling vw_eu_data_act project labels it "L" but that doesn't match a
     # real engine's oil capacity) is left uncurated; this is the meaningful
     # percentage gauge.
-    "oil_level_actual_level": {"name": "Oil level", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:oil-level"},
+    "oil_level_actual_level": {"name": "Oil level", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:oil-level", "category": EntityCategory.DIAGNOSTIC},
     "cng_gas_level": {"name": "CNG gas level", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:gas-cylinder"},
     "position_front_left_door_window_lifter": {"name": "Front left window position", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:window-open-variant", "category": EntityCategory.DIAGNOSTIC},
     "position_front_right_door_window_lifter": {"name": "Front right window position", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:window-open-variant", "category": EntityCategory.DIAGNOSTIC},
     "position_rear_left_door_window_lifter": {"name": "Rear left window position", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:window-open-variant", "category": EntityCategory.DIAGNOSTIC},
     "position_rear_right_door_window_lifter": {"name": "Rear right window position", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:window-open-variant", "category": EntityCategory.DIAGNOSTIC},
     "position_sunroof_motor_hood_1": {"name": "Sunroof position", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:car-convertible", "category": EntityCategory.DIAGNOSTIC},
-    "inspection_due_days": {"name": "Inspection due", "unit": UnitOfTime.DAYS, "icon": "mdi:wrench-clock"},
+    # Day-count is diagnostic (matches vag_connect's own "Entretien dans"/
+    # "Vidange dans"); the km-count stays primary (its "Prochain entretien"/
+    # "Prochaine vidange").
+    "inspection_due_days": {"name": "Inspection due", "unit": UnitOfTime.DAYS, "icon": "mdi:wrench-clock", "category": EntityCategory.DIAGNOSTIC},
     "inspection_due_km": {"name": "Inspection due", "device_class": SensorDeviceClass.DISTANCE, "unit": UnitOfLength.KILOMETERS},
-    "oil_service_due_days": {"name": "Oil service due", "unit": UnitOfTime.DAYS, "icon": "mdi:oil"},
+    "oil_service_due_days": {"name": "Oil service due", "unit": UnitOfTime.DAYS, "icon": "mdi:oil", "category": EntityCategory.DIAGNOSTIC},
     "oil_service_due_km": {"name": "Oil service due", "device_class": SensorDeviceClass.DISTANCE, "unit": UnitOfLength.KILOMETERS},
-    "last_report": {"name": "Last vehicle report", "device_class": SensorDeviceClass.TIMESTAMP, "icon": "mdi:clock-check"},
+    "last_report": {"name": "Last vehicle report", "device_class": SensorDeviceClass.TIMESTAMP, "icon": "mdi:clock-check", "category": EntityCategory.DIAGNOSTIC},
     # Vehicle health + lock history (from the authproxy)
     "warning_lights": {"name": "Warning lights", "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:car-light-alert"},
     "last_lock_action": {"name": "Last lock command", "icon": "mdi:car-key", "category": EntityCategory.DIAGNOSTIC},
@@ -359,6 +362,9 @@ class VolkswagenConnectStatusSensor(_Base):
 
     _attr_icon = "mdi:database-sync"
     _attr_translation_key = "data_status"
+    # Integration/data-plumbing health, not a vehicle metric - same bucket as
+    # the timestamp sensors below.
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(self, coordinator: VolkswagenConnectCoordinator, vin: str) -> None:
         super().__init__(coordinator, vin)
@@ -408,6 +414,7 @@ class VolkswagenConnectCapturedSensor(_Base):
     _attr_device_class = SensorDeviceClass.TIMESTAMP
     _attr_icon = "mdi:car-clock"
     _attr_name = "Data captured"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(self, coordinator: VolkswagenConnectCoordinator, vin: str) -> None:
         super().__init__(coordinator, vin)

--- a/custom_components/volkswagen_connect/strings.json
+++ b/custom_components/volkswagen_connect/strings.json
@@ -74,5 +74,31 @@
         }
       }
     }
+  },
+  "issues": {
+    "invalid_auth": {
+      "title": "Volkswagen login failed",
+      "description": "The stored email or password is no longer accepted by Volkswagen. Click Repair to log in again."
+    },
+    "account_locked": {
+      "title": "Volkswagen account locked",
+      "description": "Your Volkswagen account looks locked or disabled. Sign in at volkswagen.de to sort it out, then click Repair to log in again."
+    },
+    "throttled": {
+      "title": "Too many Volkswagen sign-in attempts",
+      "description": "Volkswagen has temporarily blocked logins for this account. Wait about 30 minutes, then click Repair to log in again."
+    },
+    "not_authorised": {
+      "title": "Volkswagen data portal not set up yet",
+      "description": "This account isn't set up on the EU Data Act portal yet. Open the portal (see Learn more), sign in, accept the consent screen, link your car and turn on a continuous 15-minute data request. Then click Repair to confirm."
+    },
+    "cannot_connect": {
+      "title": "Could not connect to Volkswagen",
+      "description": "The last attempt to reach Volkswagen's servers failed. This is usually temporary and clears on its own once the connection succeeds again."
+    },
+    "auth_failed": {
+      "title": "Volkswagen authentication failed",
+      "description": "Something went wrong logging in to Volkswagen. Click Repair to try again."
+    }
   }
 }

--- a/custom_components/volkswagen_connect/translations/en.json
+++ b/custom_components/volkswagen_connect/translations/en.json
@@ -74,5 +74,31 @@
         }
       }
     }
+  },
+  "issues": {
+    "invalid_auth": {
+      "title": "Volkswagen login failed",
+      "description": "The stored email or password is no longer accepted by Volkswagen. Click Repair to log in again."
+    },
+    "account_locked": {
+      "title": "Volkswagen account locked",
+      "description": "Your Volkswagen account looks locked or disabled. Sign in at volkswagen.de to sort it out, then click Repair to log in again."
+    },
+    "throttled": {
+      "title": "Too many Volkswagen sign-in attempts",
+      "description": "Volkswagen has temporarily blocked logins for this account. Wait about 30 minutes, then click Repair to log in again."
+    },
+    "not_authorised": {
+      "title": "Volkswagen data portal not set up yet",
+      "description": "This account isn't set up on the EU Data Act portal yet. Open the portal (see Learn more), sign in, accept the consent screen, link your car and turn on a continuous 15-minute data request. Then click Repair to confirm."
+    },
+    "cannot_connect": {
+      "title": "Could not connect to Volkswagen",
+      "description": "The last attempt to reach Volkswagen's servers failed. This is usually temporary and clears on its own once the connection succeeds again."
+    },
+    "auth_failed": {
+      "title": "Volkswagen authentication failed",
+      "description": "Something went wrong logging in to Volkswagen. Click Repair to try again."
+    }
   }
 }

--- a/custom_components/volkswagen_connect/website_portal.py
+++ b/custom_components/volkswagen_connect/website_portal.py
@@ -507,6 +507,49 @@ class WebsitePortalClient:
             return {}
         return {"warning_lights": len(lights)}
 
+    async def get_parking_position(self, vin: str) -> dict[str, Any]:
+        """Last-parked GPS position, if the authproxy exposes it for this account.
+
+        EXPERIMENTAL: the myvolkswagen.de website itself has no "find my car"
+        map, so this proxy path may not be allow-listed at all for most
+        accounts - a 403/412 here (raised by _get() as WebsitePortalAuthError,
+        same as get_charging()'s "not every vehicle has a battery" case) just
+        means "no GPS for this account". The caller must catch that the same
+        way it already does for get_charging().
+
+        Keys: latitude, longitude, position_captured_at (ISO timestamp, if
+        present). A reported (0, 0) - VW's null-position sentinel - is
+        dropped, not passed through as a real fix.
+        """
+        gdc = await self._gdc_for(vin)
+        status, body = await self._get(
+            f"/app/authproxy/vwag-weconnect/proxy/vehicles/{vin}/parkingposition"
+            f"?gdc=myvw-{gdc}-prod&resourceHost=myvw-vcf-prod",
+            accept="*/*",
+        )
+        if status != 200:
+            _LOGGER.debug("portal parkingposition %s -> %s", vin, status)
+            return {}
+        try:
+            data = json.loads(body)
+        except ValueError:
+            return {}
+        node = data.get("data") if isinstance(data, dict) else None
+        if not isinstance(node, dict):
+            node = data if isinstance(data, dict) else {}
+        lat, lon = node.get("lat"), node.get("lon")
+        numeric = (
+            isinstance(lat, (int, float)) and not isinstance(lat, bool)
+            and isinstance(lon, (int, float)) and not isinstance(lon, bool)
+        )
+        if not numeric or (lat == 0 and lon == 0):
+            return {}
+        out: dict[str, Any] = {"latitude": float(lat), "longitude": float(lon)}
+        ts = node.get("carCapturedTimestamp")
+        if isinstance(ts, str) and ts:
+            out["position_captured_at"] = ts
+        return out
+
     async def get_lock_history(self, vin: str) -> dict[str, Any]:
         """Last *confirmed* remote lock/unlock command from the transaction log.
 

--- a/custom_components/volkswagen_connect/website_portal.py
+++ b/custom_components/volkswagen_connect/website_portal.py
@@ -76,7 +76,16 @@ class WebsitePortalError(Exception):
 
 
 class WebsitePortalAuthError(WebsitePortalError):
-    """Login/refresh failed; full re-auth (incl. OTP) needed."""
+    """Login/refresh failed; full re-auth (incl. OTP) needed.
+
+    ``reason`` optionally classifies *why*, using the same vocabulary as
+    ``EuDataActAuthError.reason`` (see ``exceptions.classify``) - "" when the
+    call site doesn't know more than "auth failed".
+    """
+
+    def __init__(self, message: str, reason: str = "") -> None:
+        super().__init__(message)
+        self.reason = reason
 
 
 class _MfaRequired(Exception):
@@ -216,7 +225,7 @@ class WebsitePortalClient:
             page_url = str(r.url)
         if "/u/login" not in page_url:
             if _is_consent_url(page_url):
-                raise WebsitePortalAuthError(_CONSENT_HINT)
+                raise WebsitePortalAuthError(_CONSENT_HINT, reason="not_authorised")
             if (urlparse(page_url).hostname or "").endswith("volkswagen.de"):
                 return "ok"  # silent SSO
             raise WebsitePortalAuthError(f"unexpected authorize landing: {page_url}")
@@ -285,7 +294,7 @@ class WebsitePortalClient:
             # history means the consent wall is bouncing us — tell the user.
             chain = [str(r.url) for r in err.history]
             if any(_is_consent_url(u) for u in chain):
-                raise WebsitePortalAuthError(_CONSENT_HINT) from err
+                raise WebsitePortalAuthError(_CONSENT_HINT, reason="not_authorised") from err
             raise WebsitePortalError(
                 f"redirect loop during silent refresh ({len(chain)} hops, "
                 f"last: {chain[-1] if chain else '?'})"
@@ -295,7 +304,7 @@ class WebsitePortalClient:
         # Consent/terms wall: checked before the generic re-auth hints so its
         # actionable message wins (old-style consent also matches /signin-service).
         if _is_consent_url(url):
-            raise WebsitePortalAuthError(_CONSENT_HINT)
+            raise WebsitePortalAuthError(_CONSENT_HINT, reason="not_authorised")
         if "/u/login" in url or "/signin-service" in url:
             raise WebsitePortalAuthError("SSO session expired; full re-auth required")
         # A failed silent auth (prompt=none) can still bounce back to the portal


### PR DESCRIPTION
## Summary
- Typed classification for auth failures (`exceptions.py`) + a Repairs UI integration, so a failing login shows an actionable message instead of the generic reauth notice.
- New entities: a button to create the EU Data Act data request from HA (removes the manual portal-visit step), a poll-interval slider, a per-vehicle service due-date calendar, absolute-date companion sensors for inspection/oil service, and an experimental GPS device_tracker (silently degrades to no entity for accounts where the authproxy doesn't expose position - confirmed live).
- EU Data Act session now persists across restarts instead of re-logging-in with a full password POST every time.
- Entity categorization pass: binary_sensor.py had no EntityCategory support at all - every one of its ~28 keys showed up as primary regardless of how technical the signal was. Sorted primary vs diagnostic to match the split a reference multi-brand integration (same backend) already uses for the same signals.
- Fixed a few duplicate sensors the categorization pass surfaced: mileage/odometer, EU Data Act's own raw maintenance-due fields duplicating the portal-sourced ones, an "echo" API-healthcheck field leaking through a fallback code path, and binary sensors that stayed permanently Unavailable instead of never being created.

## Test plan
- Verified live against a real account/vehicle for each addition (see individual commit messages for specifics).
- Not yet tested against a different vehicle type/brand than a single gasoline Tiguan - would appreciate a second pair of eyes on that.