### PR TITLE
Fix #25: per-vehicle 403 on inactive connectivity license breaks whole account

### DIFF
--- a/custom_components/volkswagen_connect/coordinator.py
+++ b/custom_components/volkswagen_connect/coordinator.py
@@ -270,7 +270,22 @@ class VolkswagenConnectCoordinator(DataUpdateCoordinator[dict[str, VehicleData]]
                 if vin:
                     result[vin] = VehicleData(vin=vin, info={"vin": vin})
             for vin, data in result.items():
-                maint = await self.portal.get_maintenance(vin)
+                # Not every vehicle on a multi-vehicle account has an active
+                # We Connect connectivity license - one lacking it 403s (error
+                # 4007, "inactive connectivity license") on every one of these
+                # per-vehicle reads even with a perfectly valid session. Treat
+                # that as "no data for this vehicle" (same non-fatal-degrade
+                # pattern already used for get_charging() below on a
+                # combustion car), not an auth failure for the whole account -
+                # otherwise it takes down every other vehicle's data too (#25).
+                try:
+                    maint = await self.portal.get_maintenance(vin)
+                except WebsitePortalAuthError as err:
+                    _LOGGER.debug(
+                        "No maintenance data for %s (inactive connectivity "
+                        "license?): %s", vin, err,
+                    )
+                    maint = {}
                 for raw, clean in _MAINTENANCE_MAP.items():
                     if maint.get(raw) is not None:
                         data.values[clean] = maint[raw]
@@ -285,8 +300,20 @@ class VolkswagenConnectCoordinator(DataUpdateCoordinator[dict[str, VehicleData]]
                         "No charging data for %s (likely not an EV): %s", vin, err
                     )
                 # Vehicle-health warning lights + last lock/unlock command.
-                data.values.update(await self.portal.get_warning_lights(vin))
-                data.values.update(await self.portal.get_lock_history(vin))
+                try:
+                    data.values.update(await self.portal.get_warning_lights(vin))
+                except WebsitePortalAuthError as err:
+                    _LOGGER.debug(
+                        "No warning-lights data for %s (inactive connectivity "
+                        "license?): %s", vin, err,
+                    )
+                try:
+                    data.values.update(await self.portal.get_lock_history(vin))
+                except WebsitePortalAuthError as err:
+                    _LOGGER.debug(
+                        "No lock-history data for %s (inactive connectivity "
+                        "license?): %s", vin, err,
+                    )
                 # Exterior images (public CDN URLs, served by the image platform).
                 # All views in one call; a side/profile shot is the primary "Image".
                 data.image_urls = await self.portal.get_vehicle_images(vin)

--- a/custom_components/volkswagen_connect/coordinator.py
+++ b/custom_components/volkswagen_connect/coordinator.py
@@ -316,10 +316,24 @@ class VolkswagenConnectCoordinator(DataUpdateCoordinator[dict[str, VehicleData]]
                     )
                 # Exterior images (public CDN URLs, served by the image platform).
                 # All views in one call; a side/profile shot is the primary "Image".
-                data.image_urls = await self.portal.get_vehicle_images(vin)
+                try:
+                    data.image_urls = await self.portal.get_vehicle_images(vin)
+                except WebsitePortalAuthError as err:
+                    _LOGGER.debug(
+                        "No vehicle images for %s (inactive connectivity "
+                        "license?): %s", vin, err,
+                    )
+                    data.image_urls = {}
                 data.primary_image_view = _choose_primary_view(data.image_urls)
                 data.image_url = data.image_urls.get(data.primary_image_view or "")
-                info = await self.portal.get_vehicle_info(vin)
+                try:
+                    info = await self.portal.get_vehicle_info(vin)
+                except WebsitePortalAuthError as err:
+                    _LOGGER.debug(
+                        "No vehicle info for %s (inactive connectivity "
+                        "license?): %s", vin, err,
+                    )
+                    info = {}
                 for k in ("nickName", "nickname", "licensePlate", "modelName", "engine", "exteriorColor"):
                     if info.get(k) and not data.info.get(k):
                         data.info[k] = info[k]


### PR DESCRIPTION
Fixes #25.

## Summary
- get_maintenance()/get_warning_lights()/get_lock_history() had no per-vehicle  403 handling, unlike get_charging() (already fixed in #21). On a multi-vehicle account where one car's We Connect connectivity license is  inactive (HTTP 403, error 4007), that propagated all the way up to  ConfigEntryAuthFailed for the whole config entry - every poll cycle  re-logged-in, immediately failed again on the affected vehicle, and looped,  taking down every other vehicle's data with it.
- Also wrapped get_vehicle_images()/get_vehicle_info() the same way: the  original debug log only shows get_maintenance() failing because it was the  first per-vehicle call in the loop to hit the exception and abort - nothing  in the log rules out the same 403 on these two, which go through the exact  same _get() and can raise the exact same WebsitePortalAuthError. Leaving  them unwrapped would keep the reauth-loop bug alive via a different code  path the moment either is reached for such a vehicle.
- All five calls now use the same non-fatal-degrade pattern already  established for get_charging(): a ebsitePortalAuthError here means "no  data for this vehicle", not a dead session.

## Not included
- The "nice-to-have" explicit per-VIN exclusion mechanism mentioned in the  issue - per-vehicle error isolation alone removes the reauth-loop symptom,  so it didn't seem necessary to also add an opt-out toggle.

## Test plan
- Verified: integration reloads cleanly with no regression on a single-vehicle  account (the reported scenario needs a second vehicle with an inactive  license to reproduce, which I don't have - would appreciate the original  reporter or another multi-vehicle user confirming).