### PR TITLE
Entity duplicates + primary/diagnostic categorization

### DIFF
--- a/custom_components/volkswagen_connect/binary_sensor.py
+++ b/custom_components/volkswagen_connect/binary_sensor.py
@@ -16,6 +16,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -29,10 +30,13 @@ from .coordinator import VolkswagenConnectConfigEntry, VolkswagenConnectCoordina
 BINARY_KEYS: dict[str, dict[str, Any]] = {
     "locked": {"name": "Lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True},
     "open": {"name": "Open", "device_class": BinarySensorDeviceClass.OPENING},
-    "trunk.locked": {"name": "Trunk lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True},
+    # Detailed lock states for a secondary component (vs. the flat "locked"
+    # aggregate above) - diagnostic, matching how the reference vag_connect
+    # integration buckets its own "Coffre verrouillé"/"Capot verrouillé".
+    "trunk.locked": {"name": "Trunk lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "category": EntityCategory.DIAGNOSTIC},
     "trunk.open": {"name": "Trunk", "device_class": BinarySensorDeviceClass.OPENING},
-    "parking_brake": {"name": "Parking brake", "encoding": "onoff"},
-    "parking_lights": {"name": "Parking lights", "device_class": BinarySensorDeviceClass.LIGHT, "encoding": "lights"},
+    "parking_brake": {"name": "Parking brake", "encoding": "onoff", "category": EntityCategory.DIAGNOSTIC},
+    "parking_lights": {"name": "Parking lights", "device_class": BinarySensorDeviceClass.LIGHT, "encoding": "lights", "category": EntityCategory.DIAGNOSTIC},
     # Per-door/component state fields from the EU Data Act "access" cluster.
     # VW encodes these as 0=unsupported, 1=invalid, 2/3=the two real states
     # (which one is "2" depends on the field - see each comment below). This
@@ -42,15 +46,17 @@ BINARY_KEYS: dict[str, dict[str, Any]] = {
     # The raw code is still exposed as the `raw_value` attribute so you can
     # verify it yourself (open a door, watch it flip between 2 and 3).
     #
-    # Lock states: 2 = locked, 3 = unlocked.
-    "locked_state_front_left_door": {"name": "Front left door lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state"},
-    "locked_state_front_right_door": {"name": "Front right door lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state"},
+    # Lock states: 2 = locked, 3 = unlocked. Per-door/component detail beyond
+    # the flat "locked" aggregate above - diagnostic, same reasoning as
+    # trunk.locked/parking_brake above.
+    "locked_state_front_left_door": {"name": "Front left door lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    "locked_state_front_right_door": {"name": "Front right door lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
     # VW's own dataFieldName has a double underscore here (confirmed against
     # the actual delivered payload) - every other door uses a single one.
-    "locked_state__rear_left_door": {"name": "Rear left door lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state"},
-    "locked_state_rear_right_door": {"name": "Rear right door lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state"},
-    "locked_state_tailgate": {"name": "Tailgate lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state"},
-    "locked_state_front_engine_bonnet": {"name": "Bonnet lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state"},
+    "locked_state__rear_left_door": {"name": "Rear left door lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    "locked_state_rear_right_door": {"name": "Rear right door lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    "locked_state_tailgate": {"name": "Tailgate lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    "locked_state_front_engine_bonnet": {"name": "Bonnet lock", "device_class": BinarySensorDeviceClass.LOCK, "invert": True, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
     # Open states: 2 = open, 3 = closed.
     "open_state_front_left_door": {"name": "Front left door", "device_class": BinarySensorDeviceClass.DOOR, "encoding": "state"},
     "open_state_front_right_door": {"name": "Front right door", "device_class": BinarySensorDeviceClass.DOOR, "encoding": "state"},
@@ -63,22 +69,29 @@ BINARY_KEYS: dict[str, dict[str, Any]] = {
     # produced "Dangereux" on every door/hood/tailgate while fully closed and
     # locked — so this field is inverted relative to the others: observed
     # behaviour is 2 = unsafe, 3 = safe (properly latched).
-    "safe_state_front_left_door": {"name": "Front left door latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state"},
-    "safe_state_front_right_door": {"name": "Front right door latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state"},
-    "safe_state_rear_left_door": {"name": "Rear left door latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state"},
-    "safe_state_rear_right_door": {"name": "Rear right door latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state"},
-    "safe_state_tailgate": {"name": "Tailgate latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state"},
-    "safe_state_front_engine_bonnet": {"name": "Bonnet latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state"},
-    # Window lifter / sunroof states: 2 = open, 3 = closed.
+    "safe_state_front_left_door": {"name": "Front left door latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    "safe_state_front_right_door": {"name": "Front right door latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    "safe_state_rear_left_door": {"name": "Rear left door latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    "safe_state_rear_right_door": {"name": "Rear right door latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    "safe_state_tailgate": {"name": "Tailgate latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    "safe_state_front_engine_bonnet": {"name": "Bonnet latched", "device_class": BinarySensorDeviceClass.SAFETY, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    # Window lifter / sunroof open-state: 2 = open, 3 = closed. Kept primary -
+    # the reference vag_connect integration shows its own window/sunroof
+    # open-state entities as plain primary sensors, not diagnostic (only the
+    # numeric *position%* sensors in sensor.py are diagnostic there).
     "state_front_left_door_window_lifter": {"name": "Front left window", "device_class": BinarySensorDeviceClass.WINDOW, "encoding": "state"},
     "state_front_right_door_window_lifter": {"name": "Front right window", "device_class": BinarySensorDeviceClass.WINDOW, "encoding": "state"},
     "state_rear_left_door_window_lifter": {"name": "Rear left window", "device_class": BinarySensorDeviceClass.WINDOW, "encoding": "state"},
     "state_rear_right_door_window_lifter": {"name": "Rear right window", "device_class": BinarySensorDeviceClass.WINDOW, "encoding": "state"},
     "state_sunroof_motor_hood_1": {"name": "Sunroof", "device_class": BinarySensorDeviceClass.WINDOW, "encoding": "state"},
-    "state_sunroof_motor_hood_3": {"name": "Sunroof motor 3", "encoding": "state"},
+    "state_sunroof_motor_hood_3": {"name": "Sunroof motor 3", "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    # Likely the ID.x/dotted counterpart of the flat "open_state_front_engine_bonnet"
+    # above (same pattern as mileage/odometer or outdoor/outside_temperature) - kept
+    # primary like its sibling rather than diagnostic, since only one of the two
+    # ever populates per vehicle.
     "state_of_hood": {"name": "Hood", "device_class": BinarySensorDeviceClass.OPENING, "encoding": "state"},
-    "state_service_hatch": {"name": "Service hatch (fuel/charge flap)", "device_class": BinarySensorDeviceClass.OPENING, "encoding": "state"},
-    "state_spoiler": {"name": "Spoiler", "device_class": BinarySensorDeviceClass.OPENING, "encoding": "state"},
+    "state_service_hatch": {"name": "Service hatch (fuel/charge flap)", "device_class": BinarySensorDeviceClass.OPENING, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
+    "state_spoiler": {"name": "Spoiler", "device_class": BinarySensorDeviceClass.OPENING, "encoding": "state", "category": EntityCategory.DIAGNOSTIC},
 }
 
 _TRUE = {"true", "1", "on", "yes"}
@@ -160,10 +173,19 @@ async def async_setup_entry(
     def _add_new() -> None:
         new: list[BinarySensorEntity] = []
         for vin, vehicle in (coordinator.data or {}).items():
-            for key in BINARY_KEYS:
-                if key in vehicle.values and (vin, key) not in known:
-                    known.add((vin, key))
-                    new.append(VolkswagenConnectBinarySensor(coordinator, vin, key))
+            for key, meta in BINARY_KEYS.items():
+                if (vin, key) in known or key not in vehicle.values:
+                    continue
+                decode = _DECODERS[meta.get("encoding", "bool")]
+                if decode(vehicle.values[key]) is None:
+                    # Key present but not yet a meaningful reading (VW's own
+                    # "0/1 = unsupported/invalid" placeholder) - skip creating
+                    # an entity that would just sit as permanently
+                    # Unavailable; re-checked on every update in case a later
+                    # delivery actually reports a real state.
+                    continue
+                known.add((vin, key))
+                new.append(VolkswagenConnectBinarySensor(coordinator, vin, key))
         if new:
             async_add_entities(new)
 
@@ -202,6 +224,8 @@ class VolkswagenConnectBinarySensor(
         self._attr_name = meta["name"]
         if "device_class" in meta:
             self._attr_device_class = meta["device_class"]
+        if "category" in meta:
+            self._attr_entity_category = meta["category"]
 
     @property
     def _vehicle(self) -> VehicleData | None:

--- a/custom_components/volkswagen_connect/coordinator.py
+++ b/custom_components/volkswagen_connect/coordinator.py
@@ -100,13 +100,23 @@ _MAINTENANCE_MAP = {
 # raw EU Data Act duplicate is dropped. Only applied when the portal value is
 # actually present, so nothing disappears if the portal is unavailable.
 _PORTAL_DUPLICATES = {
-    "odometer": ("mileage.value",),
+    # Both the dotted (ID.x) and flat (pre-ID.x) EU Data Act mileage keys
+    # duplicate the portal's "odometer" - this Tiguan sends the flat one.
+    "odometer": ("mileage.value", "mileage"),
     "soc": ("battery_level_HV.value", "battery_state_report.soc"),
     "charge_power": ("battery_state_report.charge_power",),
     "charge_rate": ("battery_state_report.charge_rate",),
     "charging_state": ("charging_state_report.current_charge_state",),
     "charge_mode": ("charging_state_report.charge_mode",),
     "charge_time_remaining": ("battery_state_report.remaining_charging_time_complete",),
+    # EU Data Act's own raw maintenance-due fields duplicate _MAINTENANCE_MAP's
+    # portal-sourced values (confirmed live: same magnitude, opposite sign,
+    # no unit - entity id sensor.garage_tiguan_maintenance_interval_distance_
+    # until_inspection).
+    "inspection_due_km": ("maintenance_interval_distance_until_inspection",),
+    "inspection_due_days": ("maintenance_interval_time_until_inspection",),
+    "oil_service_due_km": ("maintenance_interval_distance_until_oil_change",),
+    "oil_service_due_days": ("maintenance_interval_time_until_oil_change",),
 }
 
 # EU Data Act fields carrying the moment the car *captured* the data (as opposed

--- a/custom_components/volkswagen_connect/eu_data_act.py
+++ b/custom_components/volkswagen_connect/eu_data_act.py
@@ -268,6 +268,14 @@ def _extract_values(raw: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
                 out[name] = _coerce(r.get("value"))
         elif isinstance(doc, (dict, list)):
             out.update(flatten(doc))
+    # flatten()'s generic fallback (used for docs that aren't shaped as the
+    # expected records list) has no notion of _SKIP_FIELDS, so an envelope
+    # field like "echo" can leak through under a dotted path (e.g.
+    # "some.prefix.echo") instead of the bare name the per-record loop above
+    # already filters. Catch that here, matched on the final path segment.
+    for key in list(out):
+        if key.rsplit(".", 1)[-1] in _SKIP_FIELDS:
+            del out[key]
     return out, latest_ts
 
 

--- a/custom_components/volkswagen_connect/image.py
+++ b/custom_components/volkswagen_connect/image.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from homeassistant.components.image import ImageEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
@@ -83,6 +84,7 @@ class VolkswagenConnectVehicleImage(CoordinatorEntity[VolkswagenConnectCoordinat
             self._attr_unique_id = f"{vin}_image_{view}"
             self._attr_name = f"Image {view.replace('_', ' ')}"
             self._attr_entity_registry_enabled_default = False
+            self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._current_url: str | None = None
         url = self._url
         if url:

--- a/custom_components/volkswagen_connect/sensor.py
+++ b/custom_components/volkswagen_connect/sensor.py
@@ -104,18 +104,21 @@ KNOWN_KEYS: dict[str, dict[str, Any]] = {
     # sibling vw_eu_data_act project labels it "L" but that doesn't match a
     # real engine's oil capacity) is left uncurated; this is the meaningful
     # percentage gauge.
-    "oil_level_actual_level": {"name": "Oil level", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:oil-level"},
+    "oil_level_actual_level": {"name": "Oil level", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:oil-level", "category": EntityCategory.DIAGNOSTIC},
     "cng_gas_level": {"name": "CNG gas level", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:gas-cylinder"},
     "position_front_left_door_window_lifter": {"name": "Front left window position", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:window-open-variant", "category": EntityCategory.DIAGNOSTIC},
     "position_front_right_door_window_lifter": {"name": "Front right window position", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:window-open-variant", "category": EntityCategory.DIAGNOSTIC},
     "position_rear_left_door_window_lifter": {"name": "Rear left window position", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:window-open-variant", "category": EntityCategory.DIAGNOSTIC},
     "position_rear_right_door_window_lifter": {"name": "Rear right window position", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:window-open-variant", "category": EntityCategory.DIAGNOSTIC},
     "position_sunroof_motor_hood_1": {"name": "Sunroof position", "unit": PERCENTAGE, "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:car-convertible", "category": EntityCategory.DIAGNOSTIC},
-    "inspection_due_days": {"name": "Inspection due", "unit": UnitOfTime.DAYS, "icon": "mdi:wrench-clock"},
+    # Day-count is diagnostic (matches vag_connect's own "Entretien dans"/
+    # "Vidange dans"); the km-count stays primary (its "Prochain entretien"/
+    # "Prochaine vidange").
+    "inspection_due_days": {"name": "Inspection due", "unit": UnitOfTime.DAYS, "icon": "mdi:wrench-clock", "category": EntityCategory.DIAGNOSTIC},
     "inspection_due_km": {"name": "Inspection due", "device_class": SensorDeviceClass.DISTANCE, "unit": UnitOfLength.KILOMETERS},
-    "oil_service_due_days": {"name": "Oil service due", "unit": UnitOfTime.DAYS, "icon": "mdi:oil"},
+    "oil_service_due_days": {"name": "Oil service due", "unit": UnitOfTime.DAYS, "icon": "mdi:oil", "category": EntityCategory.DIAGNOSTIC},
     "oil_service_due_km": {"name": "Oil service due", "device_class": SensorDeviceClass.DISTANCE, "unit": UnitOfLength.KILOMETERS},
-    "last_report": {"name": "Last vehicle report", "device_class": SensorDeviceClass.TIMESTAMP, "icon": "mdi:clock-check"},
+    "last_report": {"name": "Last vehicle report", "device_class": SensorDeviceClass.TIMESTAMP, "icon": "mdi:clock-check", "category": EntityCategory.DIAGNOSTIC},
     # Vehicle health + lock history (from the authproxy)
     "warning_lights": {"name": "Warning lights", "state_class": SensorStateClass.MEASUREMENT, "icon": "mdi:car-light-alert"},
     "last_lock_action": {"name": "Last lock command", "icon": "mdi:car-key", "category": EntityCategory.DIAGNOSTIC},
@@ -341,6 +344,9 @@ class VolkswagenConnectStatusSensor(_Base):
 
     _attr_icon = "mdi:database-sync"
     _attr_translation_key = "data_status"
+    # Integration/data-plumbing health, not a vehicle metric - same bucket as
+    # the timestamp sensors below.
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(self, coordinator: VolkswagenConnectCoordinator, vin: str) -> None:
         super().__init__(coordinator, vin)
@@ -390,6 +396,7 @@ class VolkswagenConnectCapturedSensor(_Base):
     _attr_device_class = SensorDeviceClass.TIMESTAMP
     _attr_icon = "mdi:car-clock"
     _attr_name = "Data captured"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(self, coordinator: VolkswagenConnectCoordinator, vin: str) -> None:
         super().__init__(coordinator, vin)


### PR DESCRIPTION
- binary_sensor.py had no EntityCategory support at all - every one of its  ~28 keys showed up as primary regardless of how technical the signal was. Added category support and bucketed per-door/component lock detail,  parking brake/lights, and the safety-latch states as diagnostic - only the  flat "locked"/"open" aggregates and door/window open-state stay primary.
- Also moved "Data status"/"Data captured"/"Last vehicle report" (data-plumbing health, not vehicle state), the day-count maintenance fields (their km-count siblings stay primary), oil level %, and secondary image views to diagnostic.
- Fixed three real duplicates the categorization pass surfaced:
   - "mileage" (flat EU Data Act key) duplicated "odometer" (portal) -    _PORTAL_DUPLICATES only stripped the dotted "mileage.value" variant.
  - Four uncurated EU Data Act fields (maintenance_interval_distance/time_until_inspection/oil_change) duplicated the portal-sourced "Inspection due"/"Oil service due" pair - same magnitude, opposite sign, no unit.
  - binary_sensor.py created an entity for any key present in the payload even when it never decoded to a real state (VW's 0/1 "unsupported/invalid" placeholder) - e.g. "Hood"/"Service hatch"/"Spoiler" sat  permanently Unavailable next to a working sibling. Now only created once the value actually decodes.
- eu_data_act.py's flatten() fallback path had no _SKIP_FIELDS filtering,  letting the "echo" API-healthcheck field leak through as a visible  diagnostic sensor. Filtered on the final dotted path segment.